### PR TITLE
chore(deps): Rust 1.96 に更新

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -14,7 +14,7 @@
 #   mise run gen-ts      Rust の Config 系 type から frontend/src/lib/config.ts を生成 (build 依存に組込済)
 
 [tools]
-rust = "1.95"
+rust = "1.96"
 node = "lts"
 
 [tasks.setup]


### PR DESCRIPTION
## Summary
- `mise.toml` の Rust ツールチェーンを 1.95 → 1.96 に更新

## 破壊的変更の確認
[Rust 1.96.0 リリースノート](https://blog.rust-lang.org/2026/05/28/Rust-1.96.0/) を確認。唯一の破壊的変更は WebAssembly ターゲットの `--allow-undefined` フラグ削除で、本プロジェクトは wasm ターゲットを使用していないため影響なし。

## Test plan
- [x] `mise install` で Rust 1.96.0 インストール成功
- [x] `mise run build` ビルド成功
- [x] `mise run test` 65 テスト全通過
- [x] `cargo clippy --workspace --all-targets` 既存警告3件のみ（本変更起因なし）

Closes #212