### PR TITLE
fix: update スクリプトの \s を [[:space:]] に統一

### DIFF
--- a/scripts/install/update-macos.sh
+++ b/scripts/install/update-macos.sh
@@ -35,7 +35,7 @@ echo "最新バージョンを確認しています..."
 api_response=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest")
 
 # jq なしで tag_name を抽出
-latest_tag=$(echo "$api_response" | grep -o '"tag_name"\s*:\s*"[^"]*"' | sed 's/"tag_name"\s*:\s*"\(.*\)"/\1/')
+latest_tag=$(echo "$api_response" | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/"tag_name"[[:space:]]*:[[:space:]]*"\(.*\)"/\1/')
 
 if [ -z "$latest_tag" ]; then
     echo "[ERROR] 最新バージョンの取得に失敗しました"

--- a/scripts/install/update.sh
+++ b/scripts/install/update.sh
@@ -27,7 +27,7 @@ else
 fi
 
 # jq なしで tag_name を抽出
-latest_tag=$(echo "$api_response" | grep -o '"tag_name"\s*:\s*"[^"]*"' | sed 's/"tag_name"\s*:\s*"\(.*\)"/\1/')
+latest_tag=$(echo "$api_response" | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/"tag_name"[[:space:]]*:[[:space:]]*"\(.*\)"/\1/')
 
 if [ -z "$latest_tag" ]; then
     echo "[ERROR] 最新バージョンの取得に失敗しました"
@@ -41,7 +41,7 @@ if command -v muhenkan-switch-core &>/dev/null; then
     version_output=$(muhenkan-switch-core --version 2>/dev/null || true)
     if [ -n "$version_output" ]; then
         # "muhenkan-switch-core x.y.z" → "vx.y.z"
-        version_string=$(echo "$version_output" | sed 's/^muhenkan-switch-core\s*//')
+        version_string=$(echo "$version_output" | sed 's/^muhenkan-switch-core[[:space:]]*//')
         current_version="v$version_string"
     fi
 fi


### PR DESCRIPTION
## 概要

Closes #219

`scripts/install/update-macos.sh` と `scripts/install/update.sh` の `tag_name` 抽出・バージョン文字列抽出で GNU 拡張の `\s` を使用しており、BSD grep/sed (macOS 標準) では空白にマッチしないため `latest_tag` が空になり「最新バージョンの取得に失敗しました」で毎回失敗する問題を修正。

既に POSIX 互換で実装されている `scripts/install/get.sh:63` と同じ `[[:space:]]` に統一した。

## 変更内容

- `scripts/install/update-macos.sh:38`: `grep -o '"tag_name"\s*:\s*"[^"]*"'` / `sed 's/"tag_name"\s*:\s*"\(.*\)"/\1/'` → `[[:space:]]` に置換
- `scripts/install/update.sh:30`: 同上
- `scripts/install/update.sh:44`: `sed 's/^muhenkan-switch-core\s*//'` → `[[:space:]]` に置換

`scripts/` 全体を grep して他に GNU 拡張 `\s` を使う箇所が残っていないことも確認済み(上記 3 箇所のみ)。

## 検証結果

- `bash -n` で 3 スクリプト (`update-macos.sh` / `update.sh` / `get.sh`) すべて構文エラーなしを確認
- 機能テスト: 修正後の grep/sed パイプラインを実際に実行し、コロン後に空白がある JSON (`{"tag_name": "v0.11.4", "name": "x"}`) から `v0.11.4` を正しく抽出できることを確認
- `muhenkan-switch-core x.y.z` 形式の version 文字列抽出も同様に確認
- shellcheck は本環境に未インストールのため未実行 (CI 強化 issue で別途対応予定)
- **macOS 実機では未検証** (Linux 開発環境上での GNU grep/sed による動作確認のみ。`[[:space:]]` は POSIX 標準クラスのため BSD grep/sed でも動作するはずだが、実機確認は別途必要)

## テストプラン

- [ ] macOS 実機で `update-macos.sh` を実行し、バージョン取得が成功することを確認