### PR TITLE
fix(dev): fetch-kanata.sh の Windows 展開を unzip 非依存に

### DIFF
--- a/scripts/dev/fetch-kanata.sh
+++ b/scripts/dev/fetch-kanata.sh
@@ -50,7 +50,16 @@ mkdir -p "$DLDIR"
 echo "Downloading kanata ${VERSION} (${ASSET})..."
 curl -fsSL "$URL" -o "$DLDIR/kanata.zip"
 
-unzip -o "$DLDIR/kanata.zip" "$BINARY" -d "$DLDIR"
+case "$SYSTEM" in
+  MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    # Git for Windows (MSYS2) does not ship unzip, but its bundled bsdtar
+    # (via `tar`) can extract zip archives, unlike GNU tar on Linux.
+    tar -xf "$DLDIR/kanata.zip" -C "$DLDIR" "$BINARY"
+    ;;
+  *)
+    unzip -o "$DLDIR/kanata.zip" "$BINARY" -d "$DLDIR"
+    ;;
+esac
 
 if [ -f "$DLDIR/$BINARY" ]; then
   cp "$DLDIR/$BINARY" "$DEST"


### PR DESCRIPTION
## 概要

Closes #227

`scripts/dev/fetch-kanata.sh` は Windows_NT/MINGW 分岐を持ちながら、kanata バイナリの展開に `unzip` を使用していた。Git for Windows (MSYS2) には `unzip` が標準で含まれないため、Windows 開発環境で `mise run fetch-kanata` / `mise run dev` が失敗しうる問題を修正する。

## 変更内容

- `scripts/dev/fetch-kanata.sh` の zip 展開部分を OS 分岐化:
  - Windows (`MINGW*|MSYS*|CYGWIN*|Windows_NT`): `tar -xf` を使用。Git for Windows 同梱の `tar` は bsdtar (libarchive) であり zip 展開に対応しているため、追加の依存なしで動作する
  - Linux / macOS: 従来通り `unzip -o` を使用 (GNU tar は zip 展開非対応のため、この分岐は変更していない)
- release.yml (168-179 行、PowerShell `Expand-Archive` を使用) とは別に、bash スクリプト内で完結する方式を採用 (`pwsh` 呼び出しを避け、既存の bash フローを維持)

## 検証結果

- `bash -n scripts/dev/fetch-kanata.sh` — 構文エラーなし
- Linux 環境で `mise run fetch-kanata` を実行し、既存の Linux 分岐 (`unzip` 使用) が壊れていないことを確認:
  ```
  Downloading kanata v1.11.0 (linux-binaries-x64.zip)...
  Archive:  .tmp-kanata-dl/kanata.zip
    inflating: .tmp-kanata-dl/kanata_linux_cmd_allowed_x64
  Done -> ./bin/kanata_cmd_allowed (prebuilt)
  ```
  ダウンロードしたバイナリも `--version` で正常動作を確認済み
- Windows 分岐 (`tar -xf` によるzip展開) はこの Linux マシンでは実行不能なため未検証。Git for Windows に同梱される `tar` は bsdtar (libarchive ベース) であり、zip アーカイブの展開に標準対応していることは既知の挙動 (GNU tar と異なり libarchive は複数フォーマットを自動判別して展開できる)。`-C` でのディレクトリ指定・展開対象ファイル名の指定もbsdtarの標準オプションとしてサポートされている