### PR TITLE
fix: DISPATCH_KEYS から z を削除し kbd と一致させる

### DIFF
--- a/muhenkan-switch/frontend/src/lib/state.ts
+++ b/muhenkan-switch/frontend/src/lib/state.ts
@@ -73,6 +73,5 @@ export const DISPATCH_KEYS: readonly string[] = [
   'd',
   'f',
   'g',
-  'z',
   'b',
 ];


### PR DESCRIPTION
## 概要

Closes #218

GUI の割当キードロップダウン (`DISPATCH_KEYS`) に `'z'` が含まれていたが、`kanata/muhenkan.kbd` / `kanata/muhenkan-macos.kbd` の dispatch エイリアスには `dsp-z` が存在せず、`mh-layer` の z 位置は `@ts-toggle` (タイムスタンプ位置トグル) に固定されていた。そのため z にフォルダ/アプリ/検索を割り当てても常にタイムスタンプ位置トグルが実行され、割当が無反応になっていた。

## 変更内容

- `muhenkan-switch/frontend/src/lib/state.ts` の `DISPATCH_KEYS` から `'z'` を削除し、kbd 側の dispatch エイリアス集合 `{1-5, q, w, e, r, t, a, s, d, f, g, b}` (16 個) と一致させた

## 調査結果

- `kanata/muhenkan.kbd` / `kanata/muhenkan-macos.kbd` の dispatch エイリアスは `dsp-1〜5, dsp-q, dsp-w, dsp-e, dsp-r, dsp-t, dsp-a, dsp-s, dsp-d, dsp-f, dsp-g, dsp-b` の 16 個のみで確認済み
- `docs/design.md` の対応表 (`| dispatch (config.toml で自由に割当) | 1-5, q, r, t, g, a, w, e, s, d, f, b | ...`) は元々 z を含んでおらず、修正不要
- `docs/customize.md` / `help.html` / `config/default-*.toml` に z を割当可能とする記述なし (grep で確認)
- `dispatch-key.ts` / `dispatch-key.test.ts` は `DISPATCH_KEYS` を動的に参照しており、ハードコードされた `'z'` 参照なし。修正不要

## 検証結果

`muhenkan-switch/frontend/` にて実行:

- `npm ci` — OK
- `npm run typecheck` — OK (エラーなし)
- `npm run lint` — OK (エラー・警告なし)
- `npm run format:check` — OK (`All matched files use Prettier code style!`)
- `npm run test` — OK (3 test files / 34 tests 全て pass、対象ファイル coverage 100%)