### PR TITLE
fix: kanata 再起動後にクラッシュ通知が復帰しない不具合を修正

### DIFF
--- a/muhenkan-switch/src/kanata.rs
+++ b/muhenkan-switch/src/kanata.rs
@@ -331,6 +331,10 @@ impl KanataManager {
             job.assign(pid);
         }
 
+        // 起動成功。以前の stop() による意図的停止フラグをクリアし、
+        // 監視スレッドが次回のクラッシュを通知できるようにする。
+        self.intentional_stop.store(false, Ordering::SeqCst);
+
         *guard = Some(Arc::new(child));
 
         Ok(())
@@ -357,6 +361,44 @@ impl KanataManager {
             }
             None => (false, None),
         }
+    }
+}
+
+// ── Tests ──
+//
+// start() は実際の kanata バイナリ（bin/kanata_cmd_allowed）が無いと
+// 起動に失敗するため、ここでは start() を伴わずに検証できる
+// intentional_stop フラグの初期値・stop() による更新のみをテストする。
+// start() 成功時のフラグリセット（本 Issue の修正本体）を含む
+// stop → start の完全な状態遷移テストは、実バイナリの用意または
+// プロセス起動を差し替える依存性注入が必要になり invasive なため見送る
+// （テスト整備は Issue #230 で扱う）。
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_intentional_stop_flag_initial_false() {
+        let manager = KanataManager::new();
+        assert!(!manager.intentional_stop_flag().load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn stop_without_running_child_sets_intentional_stop_flag() {
+        let manager = KanataManager::new();
+        let flag = manager.intentional_stop_flag();
+        assert!(!flag.load(Ordering::SeqCst));
+
+        let result = manager.stop();
+
+        assert!(result.is_ok());
+        assert!(flag.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn status_with_no_child_returns_not_running() {
+        let manager = KanataManager::new();
+        assert_eq!(manager.status(), (false, None));
     }
 }
 


### PR DESCRIPTION
## 概要

Closes #217

`KanataManager::start()` が成功しても `intentional_stop` フラグをリセットしていなかったため、一度でも `stop()` (設定保存・トレイ操作等) が走ると、以後 kanata が異常終了しても監視スレッドのクラッシュ通知 (「キー割当が停止しました」) が二度と出なくなる不具合を修正しました。

## 変更内容

- `muhenkan-switch/src/kanata.rs`: `start()` 内でプロセス起動成功後 (`*guard = Some(...)` の直前) に `self.intentional_stop.store(false, Ordering::SeqCst);` を追加
- 監視スレッド (kanata.rs:481 付近) のロジック (`last_running && !running && !intentional_flag`) と整合することを確認: フラグのリセットは guard のロックを保持したまま行うため、監視スレッドが次にロックを取得する時点では既に「新しい子プロセスが起動済み・フラグは false」の状態になっており、競合は発生しない
- `KanataManager` の状態遷移テストを追加 (`intentional_stop` の初期値、`stop()` によるフラグ更新、`status()` の初期状態)

## テストについて

`start()` は実際の kanata バイナリ (`bin/kanata_cmd_allowed`) が存在しないと起動に失敗するため、本 PR のテストでは `start()` を伴わずに検証できる範囲 (フラグの初期値・`stop()` による更新) のみをカバーしています。`stop() → start()` の完全な状態遷移 (本修正のフラグリセット自体) を検証するテストは、実バイナリの用意またはプロセス起動を差し替える依存性注入が必要になり invasive なため見送りました。テスト整備は Issue #230 で別途対応予定です。

## 検証結果

- `cd muhenkan-switch/frontend && npm ci && npm run build` — 成功
- `cargo check -p muhenkan-switch` — 成功 (エラーなし)
- `cargo test --workspace` — 全 68 テスト成功 (新規追加の kanata::tests 3 件含む)