### PR TITLE
fix: osascript の AppleScript 文字列エスケープを共通化

### DIFF
--- a/muhenkan-switch-core/src/commands/keys.rs
+++ b/muhenkan-switch-core/src/commands/keys.rs
@@ -263,7 +263,7 @@ mod imp {
                 "-e",
                 &format!(
                     r#"tell application "System Events" to keystroke "{}""#,
-                    text
+                    crate::commands::escape_applescript_string(text)
                 ),
             ])
             .output()?;

--- a/muhenkan-switch-core/src/commands/mod.rs
+++ b/muhenkan-switch-core/src/commands/mod.rs
@@ -17,3 +17,51 @@ pub fn is_wayland() -> bool {
             .map(|v| v == "wayland")
             .unwrap_or(false)
 }
+
+/// AppleScript の文字列リテラル (`"..."`) に埋め込むための値をエスケープする。
+///
+/// `\` を先に、`"` を後にエスケープする必要がある
+/// (順序を逆にすると `"` のエスケープで挿入した `\` が再度エスケープされてしまう)。
+/// これを怠ると、選択テキスト・アプリ名・パス等に `"` や `\` を含む値で
+/// AppleScript 文字列リテラルが壊れ、細工されたコマンドが注入されうる。
+///
+/// 呼び出し元は全て `#[cfg(target_os = "macos")]` 配下だが、このマシン (Linux) では
+/// macOS 分岐がコンパイルされずテストできないため、関数自体は cfg の外に置いて
+/// 全 OS でユニットテスト可能にしている。macOS 以外のビルドでは未使用になるため
+/// dead_code を許容する。
+#[allow(dead_code)]
+pub(crate) fn escape_applescript_string(s: &str) -> String {
+    s.replace('\\', r"\\").replace('"', r#"\""#)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::escape_applescript_string;
+
+    #[test]
+    fn test_escape_applescript_string_plain_text() {
+        assert_eq!(escape_applescript_string("hello"), "hello");
+    }
+
+    #[test]
+    fn test_escape_applescript_string_double_quote() {
+        assert_eq!(escape_applescript_string(r#"say "hi""#), r#"say \"hi\""#);
+    }
+
+    #[test]
+    fn test_escape_applescript_string_backslash() {
+        assert_eq!(escape_applescript_string(r"C:\path"), r"C:\\path");
+    }
+
+    #[test]
+    fn test_escape_applescript_string_backslash_and_quote_order() {
+        // バックスラッシュを先にエスケープしないと、"\"" のエスケープで
+        // 生成した `\` がさらにエスケープされて壊れる。
+        assert_eq!(escape_applescript_string(r#"\""#), r#"\\\""#);
+    }
+
+    #[test]
+    fn test_escape_applescript_string_empty() {
+        assert_eq!(escape_applescript_string(""), "");
+    }
+}

--- a/muhenkan-switch-core/src/commands/open_gui.rs
+++ b/muhenkan-switch-core/src/commands/open_gui.rs
@@ -186,7 +186,13 @@ mod imp {
         // macOS は Tauri の WebviewWindow が osascript で正しく制御できるため
         // シグナルファイル方式は不要。
         let ok = Command::new("osascript")
-            .args(["-e", r#"tell application "muhenkan-switch" to activate"#])
+            .args([
+                "-e",
+                &format!(
+                    r#"tell application "{}" to activate"#,
+                    crate::commands::escape_applescript_string("muhenkan-switch")
+                ),
+            ])
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false);

--- a/muhenkan-switch-core/src/commands/switch_app.rs
+++ b/muhenkan-switch-core/src/commands/switch_app.rs
@@ -368,7 +368,13 @@ mod imp {
         // launch が設定されていればそちらを優先
         let target = launch.unwrap_or(app);
         Command::new("osascript")
-            .args(["-e", &format!(r#"tell application "{}" to activate"#, target)])
+            .args([
+                "-e",
+                &format!(
+                    r#"tell application "{}" to activate"#,
+                    crate::commands::escape_applescript_string(target)
+                ),
+            ])
             .output()?;
         Ok(())
     }

--- a/muhenkan-switch-core/src/commands/toast.rs
+++ b/muhenkan-switch-core/src/commands/toast.rs
@@ -257,7 +257,7 @@ mod imp {
                     "-e",
                     &format!(
                         r#"display notification "{}" with title "muhenkan-switch""#,
-                        initial_message.replace('"', r#"\""#)
+                        crate::commands::escape_applescript_string(initial_message)
                     ),
                 ])
                 .spawn();
@@ -270,7 +270,7 @@ mod imp {
                     "-e",
                     &format!(
                         r#"display notification "{}" with title "muhenkan-switch""#,
-                        message.replace('"', r#"\""#)
+                        crate::commands::escape_applescript_string(message)
                     ),
                 ])
                 .spawn();
@@ -283,7 +283,7 @@ mod imp {
                     "-e",
                     &format!(
                         r#"display notification "{}" with title "muhenkan-switch""#,
-                        message.replace('"', r#"\""#)
+                        crate::commands::escape_applescript_string(message)
                     ),
                 ])
                 .spawn();


### PR DESCRIPTION
## 概要

Closes #223

macOS 分岐の osascript 呼び出しで、文字列補間のエスケープ方針が不統一だった問題を修正。`toast.rs` の既存実装と同様に `\` → `\\`（先）、`"` → `\"`（後）の順でエスケープする共通関数 `escape_applescript_string` を用意し、全 osascript 呼び出しをこれ経由に統一した。

## 変更内容

- `muhenkan-switch-core/src/commands/mod.rs`
  - `escape_applescript_string(s: &str) -> String` を追加。呼び出し元は全て `#[cfg(target_os = "macos")]` 配下だが、開発機 (Linux) でもユニットテストできるよう関数自体は cfg の外に配置（macOS 以外のビルドでは未使用になるため `#[allow(dead_code)]` を付与）
  - ユニットテスト5件を追加（プレーンテキスト / ダブルクォート / バックスラッシュ / エスケープ順序 / 空文字列）
- `muhenkan-switch-core/src/commands/keys.rs`: `simulate_type` の `keystroke "{text}"` 補間（未エスケープ）を共通関数経由に修正
- `muhenkan-switch-core/src/commands/switch_app.rs`: `activate_window` の `tell application "{target}"` 補間（未エスケープ）を共通関数経由に修正
- `muhenkan-switch-core/src/commands/open_gui.rs`: `open_gui` の `tell application "muhenkan-switch"` を共通関数経由に統一（値は固定文字列だが、他箇所との一貫性のため）
- `muhenkan-switch-core/src/commands/toast.rs`: `show` / `finish` / `notify` の3箇所のインラインエスケープ (`.replace('"', ...)`) を共通関数に置換

`grep -rn osascript muhenkan-switch-core/src` で他に osascript を呼ぶ箇所が無いことを確認済み（`context.rs` / `timestamp.rs` の言及はコメントのみで実呼び出しなし）。

## 検証結果

- `CARGO_TARGET_DIR=... cargo test -p muhenkan-switch-core -p muhenkan-switch-config`: 70 件全て pass（新規5件含む）。`cargo test --workspace` は本 PR と無関係な既存のビルド環境要因（Tauri リソース `binaries/kanata_cmd_allowed-x86_64-unknown-linux-gnu` 未取得）で workspace 全体がビルド失敗するため、対象クレートに絞って検証した
- `cargo clippy -p muhenkan-switch-core --all-targets`: 新規warningなし（`switch_app.rs:259` の doc-lazy-continuation warning は本 PR と無関係の既存 issue。`main` ブランチでも同一警告が出ることを確認済み）
- `rustup target add aarch64-apple-darwin` の上で `cargo check -p muhenkan-switch-core --target aarch64-apple-darwin` を実行し、macOS 分岐（本 PR の変更含む）がコンパイル可能なことを確認（dead_code warning 3件のみ、いずれも本 PR と無関係の既存コード）。ただし実機 / macOS CI での動作確認は別途必要

## Test plan

- [x] `cargo test -p muhenkan-switch-core -p muhenkan-switch-config`
- [x] `cargo clippy -p muhenkan-switch-core --all-targets`
- [x] `cargo check -p muhenkan-switch-core --target aarch64-apple-darwin`
- [ ] macOS 実機 / CI での動作確認（本エージェントは Linux 環境のため未実施）