### PR TITLE
fix: Linux/macOS リリースで config.toml を同梱しない

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,10 @@ jobs:
             cp "target/${{ matrix.target }}/release/${{ matrix.gui_artifact }}" "$RELEASE_DIR/"
           fi
 
-          # 設定ファイル
-          cp config/default.toml "$RELEASE_DIR/config.toml"
+          # 設定ファイル (config.toml) は同梱しない。
+          # Windows (NSIS) と同様、初回起動時に muhenkan-switch が
+          # OS 別の埋め込みデフォルト設定 (default-linux.toml 等) から自動生成する
+          # (#220: 汎用 default.toml が同梱され OS 別デフォルトが使われない問題への対応)。
 
           # kanata 設定ファイル
           cp kanata/muhenkan.kbd "$RELEASE_DIR/"

--- a/docs/design.md
+++ b/docs/design.md
@@ -181,7 +181,10 @@ GUI (Tauri) から kanata プロセスの開始・停止・再起動を行う。
 
 - GitHub Actions で Windows (x64) / Linux (x64) / macOS (x64, aarch64) のバイナリを自動ビルド
 - タグ push (`v*`) でリリース作成
-- リリース zip には muhenkan-switch バイナリ + .kbd + config.toml を同梱
+- リリース zip には muhenkan-switch バイナリ + .kbd を同梱（config.toml は同梱しない）
+- config.toml は Windows/Linux/macOS 共通で、初回起動時に muhenkan-switch が
+  OS 別の埋め込みデフォルト設定（`default-windows.toml` / `default-linux.toml` /
+  `default-macos.toml`）から自動生成する
 - kanata 本体は同梱またはダウンロードリンクを案内
 
 ---

--- a/muhenkan-switch-config/src/lib.rs
+++ b/muhenkan-switch-config/src/lib.rs
@@ -600,6 +600,36 @@ mod tests {
         );
     }
 
+    /// OS 別埋め込みデフォルト設定 (DEFAULT_WINDOWS_CONFIG / DEFAULT_LINUX_CONFIG /
+    /// DEFAULT_MACOS_CONFIG) がホスト OS に関わらず全てパース可能で、
+    /// folders/apps が空でないことを検証する。
+    /// `default_config()` は実行時の `std::env::consts::OS` でしか分岐しないため、
+    /// CI が単一 OS でしか走らない場合、他 OS 用ファイルの破損が見逃されうる (#220)。
+    #[test]
+    fn test_all_os_default_configs_parse_and_non_empty() {
+        let cases: &[(&str, &str)] = &[
+            ("windows", DEFAULT_WINDOWS_CONFIG),
+            ("linux", DEFAULT_LINUX_CONFIG),
+            ("macos", DEFAULT_MACOS_CONFIG),
+        ];
+        for (os, raw) in cases {
+            let config: Config = toml::from_str(raw)
+                .unwrap_or_else(|e| panic!("default-{} config が不正な TOML です: {}", os, e));
+            assert!(
+                !config.folders.is_empty(),
+                "default-{} の folders が空です",
+                os
+            );
+            assert!(!config.apps.is_empty(), "default-{} の apps が空です", os);
+            assert!(
+                config.search.len() >= 5,
+                "default-{} の search エンジン数が想定未満です: {}",
+                os,
+                config.search.len()
+            );
+        }
+    }
+
     #[test]
     fn test_validate_valid_config() {
         let config = default_config();

--- a/scripts/dev/test-install.sh
+++ b/scripts/dev/test-install.sh
@@ -18,7 +18,9 @@ cp ./bin/muhenkan-switch-core "$STAGING/"
 cp ./bin/muhenkan-switch "$STAGING/" 2>/dev/null || true
 
 # 設定ファイル
-cp config/default.toml "$STAGING/config.toml"
+# config.toml は同梱しない（リリース archive と同じ構成。#220）。
+# install.sh は config.toml 不在時にスキップし、初回起動時に
+# muhenkan-switch が OS 別デフォルトから自動生成する。
 cp kanata/muhenkan.kbd "$STAGING/"
 cp kanata/muhenkan-macos.kbd "$STAGING/" 2>/dev/null || true
 

--- a/scripts/install/install-macos.sh
+++ b/scripts/install/install-macos.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 
 # muhenkan-switch インストールスクリプト (macOS)
 #
-# muhenkan-switch, config.toml, muhenkan-macos.kbd をインストールし、
-# kanata を GitHub からダウンロードします。
+# muhenkan-switch, muhenkan-macos.kbd をインストールし、kanata を GitHub からダウンロードします。
+# config.toml は同梱されないため、初回起動時に muhenkan-switch が
+# OS 別デフォルト設定から自動生成する（既存があれば保持）。
 
 # ── 未検証警告 ──
 echo ""
@@ -104,7 +105,8 @@ copy_file() {
 
 copy_file "muhenkan-switch" "muhenkan-switch"
 copy_file "muhenkan-switch-core" "muhenkan-switch-core"
-# config.toml は既存があれば保持 (バックアップは上記で取得済み)
+# config.toml はリリース archive に同梱されない (初回起動時に自動生成される)。
+# 万一同梱されていた場合も、既存の config.toml があれば保持する (バックアップは上記で取得済み)。
 if [ ! -f "$INSTALL_DIR/config.toml" ]; then
     copy_file "config.toml" "config.toml"
 fi

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 
 # muhenkan-switch インストールスクリプト (Linux)
 #
-# muhenkan-switch, config.toml, muhenkan.kbd をインストールし、
-# kanata を GitHub からダウンロードします。
+# muhenkan-switch, muhenkan.kbd をインストールし、kanata を GitHub からダウンロードします。
+# config.toml は同梱されないため、初回起動時に muhenkan-switch が
+# OS 別デフォルト設定から自動生成する（既存があれば保持）。
 # root 権限は不要です。
 
 # ── 設定 ──
@@ -72,7 +73,8 @@ copy_file() {
 
 copy_file "muhenkan-switch" "muhenkan-switch"
 copy_file "muhenkan-switch-core" "muhenkan-switch-core"
-# config.toml は既存があれば保持 (バックアップは上記で取得済み)
+# config.toml はリリース archive に同梱されない (初回起動時に自動生成される)。
+# 万一同梱されていた場合も、既存の config.toml があれば保持する (バックアップは上記で取得済み)。
 if [ ! -f "$INSTALL_DIR/config.toml" ]; then
     copy_file "config.toml" "config.toml"
 fi


### PR DESCRIPTION
## 問題

Closes #220

`.github/workflows/release.yml` が全 OS 共通で `config/default.toml` を `config.toml` として同梱していたため、Linux/macOS ユーザーには OS 別デフォルト設定 (`default-linux.toml` / `default-macos.toml`) が届かず、Linux で実在しないコマンド (`terminal` 等) や不適切な大文字小文字 (`Code` 等) を含む汎用設定が使われていた。Windows は NSIS が config.toml を同梱しないため、埋め込みの OS 別デフォルトへ正しくフォールバックしており、3 OS で不整合だった。

## 採用方針

Issue の修正案 2（config.toml の同梱をやめ、Windows と同様に初回起動時の埋め込み OS 別デフォルト生成に統一）を採用。

### 判断理由（調査結果）

- `muhenkan-switch-config/src/lib.rs` の `default_config()` は既に `std::env::consts::OS` で分岐し、`DEFAULT_WINDOWS_CONFIG` / `DEFAULT_LINUX_CONFIG` / `DEFAULT_MACOS_CONFIG`（コンパイル時埋め込み）を返す実装済み。3 OS 分の embedded default はいずれも folders/apps が非空で正しくパース可能。
- `muhenkan-switch/src/main.rs` の setup には「config.toml が exe 隣に無い、または壊れている（folders/apps が空）場合に `default_config()` から再生成する」ロジックが既存（Windows は現状これで正しく動作）。
- `scripts/install/install.sh` / `install-macos.sh` は元々 `config.toml` を**既存があれば保持**し、`copy_file` はコピー元が無ければ `[SKIP]` するだけで失敗しない実装だった。つまり **release archive から config.toml を単純に外すだけで、install スクリプト側の変更なしに Windows と同じ「初回起動時生成」方式に自然に揃う**ことを確認した。
- `update.sh` / `update-macos.sh` / `get.sh` は install スクリプトを呼ぶだけで config.toml に直接依存しない。

上記より、スクリプトやドキュメントが同梱 config.toml を前提にしている実質的な障害はなく、最も一貫性の高い修正案 2 が成立すると判断。

## 変更内容

- `.github/workflows/release.yml`: `cp config/default.toml "$RELEASE_DIR/config.toml"` を削除（Linux/macOS も Windows と同様、config.toml 非同梱に）
- `scripts/dev/test-install.sh`: 同様に config.toml のコピーを削除し、実際のリリース archive 構成に合わせた
- `scripts/install/install.sh` / `install-macos.sh`: config.toml が同梱されない旨のコメントを追記（既存ユーザー保護ロジック自体は変更なし）
- `docs/design.md`: リリース zip の同梱物の記述を更新（config.toml は同梱せず初回起動時に OS 別デフォルトから自動生成する旨を明記）
- `muhenkan-switch-config/src/lib.rs`: `test_all_os_default_configs_parse_and_non_empty` を追加。3 OS 分の embedded default 設定（`default-windows.toml` / `default-linux.toml` / `default-macos.toml`）が、テスト実行 OS に関わらず全てパース可能かつ folders/apps 非空であることを検証（従来の `test_default_config` はホスト OS の分岐しか通らないため、他 OS 用ファイルの破損を見逃す穴を埋めた）

## 検証結果

- `bash -n` で変更・関連スクリプト全て (`install.sh` / `install-macos.sh` / `update.sh` / `update-macos.sh` / `get.sh` / `test-install.sh`) 構文チェック OK
- `python3 -c "import yaml; yaml.safe_load(...)"` で `release.yml` の YAML 構文チェック OK（GitHub Actions 自体はローカル実行不能のため目視レビューで補完）
- `CARGO_TARGET_DIR=... cargo test -p muhenkan-switch-config`: 39 tests 全て pass（新規追加の `test_all_os_default_configs_parse_and_non_empty` 含む）
- `install.sh` 本体の動作を、実マシンの実インストール (`~/.local/share/muhenkan-switch`) を壊さないよう `HOME` を一時ディレクトリに差し替えた隔離環境で実行し、config.toml 非同梱の release archive 構成（`muhenkan-switch-core` バイナリ + `muhenkan.kbd` + install/uninstall/update スクリプトのみ、config.toml なし）に対して `install.sh` が `[SKIP] config.toml が見つかりません` を出しつつエラーなく完走し、インストール先に config.toml が生成されない（＝初回起動時の GUI 側生成に委譲される）ことを確認した
- `scripts/dev/test-install.sh` 自体は GUI (Tauri) の完全ビルドを要し重いため、上記の隔離実行によって当該ロジック（config.toml 非同梱時の install.sh の挙動）を個別に検証する形で代替した

## マージについて

マージは行いません。