### PR TITLE
fix: 不正タイムスタンプフォーマットでの panic を防止

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2378,6 +2378,7 @@ name = "muhenkan-switch-config"
 version = "0.11.4"
 dependencies = [
  "anyhow",
+ "chrono",
  "indexmap 2.13.0",
  "serde",
  "toml 0.8.23",

--- a/config/default-linux.toml
+++ b/config/default-linux.toml
@@ -52,6 +52,7 @@ Document = {key = "d", process = "onenote",          command = "onenote"}
 [timestamp]
 # chrono のフォーマット文字列
 # %Y=年4桁, %m=月, %d=日, %H=時, %M=分, %S=秒
+# 存在しない指定子（例: %Q）は GUI 設定画面の保存時に検証エラーとなる
 format = "%Y%m%d"
 # "before" = タイムスタンプ_ファイル名, "after" = ファイル名_タイムスタンプ
 position = "before"

--- a/config/default-macos.toml
+++ b/config/default-macos.toml
@@ -52,6 +52,7 @@ Document = {key = "d", process = "Microsoft OneNote",  command = "open -a 'Micro
 [timestamp]
 # chrono のフォーマット文字列
 # %Y=年4桁, %m=月, %d=日, %H=時, %M=分, %S=秒
+# 存在しない指定子（例: %Q）は GUI 設定画面の保存時に検証エラーとなる
 format = "%Y%m%d"
 # "before" = タイムスタンプ_ファイル名, "after" = ファイル名_タイムスタンプ
 position = "before"

--- a/config/default-windows.toml
+++ b/config/default-windows.toml
@@ -52,6 +52,7 @@ Document = {key = "d", process = "OneNote",          command = "onenote"}
 [timestamp]
 # chrono のフォーマット文字列
 # %Y=年4桁, %m=月, %d=日, %H=時, %M=分, %S=秒
+# 存在しない指定子（例: %Q）は GUI 設定画面の保存時に検証エラーとなる
 format = "%Y%m%d"
 # "before" = タイムスタンプ_ファイル名, "after" = ファイル名_タイムスタンプ
 position = "before"

--- a/config/default.toml
+++ b/config/default.toml
@@ -53,6 +53,7 @@ Document = {key = "d", process = "OneNote",  command = "onenote"}
 [timestamp]
 # chrono のフォーマット文字列
 # %Y=年4桁, %m=月, %d=日, %H=時, %M=分, %S=秒
+# 存在しない指定子（例: %Q）は GUI 設定画面の保存時に検証エラーとなる
 format = "%Y%m%d"
 # "before" = タイムスタンプ_ファイル名, "after" = ファイル名_タイムスタンプ
 position = "before"

--- a/muhenkan-switch-config/Cargo.toml
+++ b/muhenkan-switch-config/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [dependencies]
 serde.workspace = true
 anyhow.workspace = true
+chrono.workspace = true
 indexmap = { version = "2", features = ["serde"] }
 toml = "0.8"
 toml_edit = "0.22"

--- a/muhenkan-switch-config/src/lib.rs
+++ b/muhenkan-switch-config/src/lib.rs
@@ -436,6 +436,13 @@ pub fn validate(config: &Config) -> Vec<String> {
     // timestamp format の検証
     if config.timestamp.format.is_empty() {
         errors.push("タイムスタンプのフォーマットを入力してください".to_string());
+    } else if chrono::format::StrftimeItems::new(&config.timestamp.format)
+        .any(|item| item == chrono::format::Item::Error)
+    {
+        errors.push(format!(
+            "タイムスタンプのフォーマットが不正です（不明な指定子が含まれています）: \"{}\"",
+            config.timestamp.format
+        ));
     }
 
     // timestamp delimiter の検証 (空=区切りなし は許可)
@@ -764,6 +771,32 @@ mod tests {
         let errors = validate(&config);
         assert_eq!(errors.len(), 1);
         assert!(errors[0].contains("フォーマット"));
+    }
+
+    #[test]
+    fn test_validate_invalid_format_specifier() {
+        // %Q は chrono に存在しない指定子 → StrftimeItems が Item::Error を返すはず
+        let mut config = default_config();
+        config.timestamp.format = "%Q".to_string();
+        let errors = validate(&config);
+        assert_eq!(errors.len(), 1, "Expected 1 error, got: {:?}", errors);
+        assert!(errors[0].contains("不正"));
+    }
+
+    #[test]
+    fn test_validate_valid_format_specifiers() {
+        // 代表的な有効フォーマットは全て通ること
+        for format in ["%Y-%m-%d", "%Y%m%d", "%Y-%m-%d_%H-%M-%S", "%F", "%c"] {
+            let mut config = default_config();
+            config.timestamp.format = format.to_string();
+            let errors = validate(&config);
+            assert!(
+                errors.is_empty(),
+                "format '{}' should be valid, got errors: {:?}",
+                format,
+                errors
+            );
+        }
     }
 
     #[test]

--- a/muhenkan-switch-core/src/commands/timestamp.rs
+++ b/muhenkan-switch-core/src/commands/timestamp.rs
@@ -1,9 +1,36 @@
 use anyhow::Result;
-use chrono::Local;
+use chrono::{DateTime, Local};
+use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
 use super::toast::Toast;
 use crate::config::Config;
+
+/// フォールバック用の安全なタイムスタンプ書式（`chrono` の全バージョンで有効な指定子のみ）。
+const FALLBACK_TIMESTAMP_FORMAT: &str = "%Y-%m-%d";
+
+/// 日時をフォーマット文字列で文字列化する。
+///
+/// `config.toml` は `validate()` を経由せず手編集される場合があり、不正な指定子
+/// （例: `%Q`）が渡ると `chrono` の `Display` は `Err` を返す。`.to_string()` は
+/// この `Err` で panic するため、必ず `write!` 経由でエラーを捕捉し、失敗時は
+/// 警告を出したうえで安全な既定書式 [`FALLBACK_TIMESTAMP_FORMAT`] にフォールバックする
+/// （AGENTS.md の「外部要因の失敗は警告して続行」の方針に倣う）。
+pub(super) fn format_timestamp(datetime: DateTime<Local>, format: &str) -> String {
+    let mut buf = String::new();
+    if write!(buf, "{}", datetime.format(format)).is_ok() {
+        return buf;
+    }
+    eprintln!(
+        "警告: タイムスタンプのフォーマット文字列 '{}' が不正です。既定の書式 '{}' を使用します",
+        format, FALLBACK_TIMESTAMP_FORMAT
+    );
+    buf.clear();
+    // フォールバック書式は固定の有効な指定子のみで構成されるため通常は失敗しないが、
+    // 万一失敗しても panic せず空文字列を返す。
+    let _ = write!(buf, "{}", datetime.format(FALLBACK_TIMESTAMP_FORMAT));
+    buf
+}
 
 pub fn run(action: &str, config: &Config) -> Result<()> {
     let explorer_hwnd = super::context::get_foreground_explorer_hwnd();
@@ -29,7 +56,7 @@ pub fn run(action: &str, config: &Config) -> Result<()> {
         // ── C: copy ──
         // テキストコンテキスト: 現在日時のタイムスタンプを入力
         ("copy", None) => {
-            let timestamp = Local::now().format(&config.timestamp.format).to_string();
+            let timestamp = format_timestamp(Local::now(), &config.timestamp.format);
             super::keys::simulate_type(&timestamp)
         }
         ("copy", Some(hwnd)) => {
@@ -88,7 +115,7 @@ fn format_toast_result(result: &Result<Vec<PathBuf>>) -> String {
 fn file_modified_timestamp(path: &Path, format: &str) -> Result<String> {
     let modified = path.metadata()?.modified()?;
     let datetime: chrono::DateTime<Local> = modified.into();
-    Ok(datetime.format(format).to_string())
+    Ok(format_timestamp(datetime, format))
 }
 
 /// V: ファイル名にタイムスタンプを付加してリネーム（ファイル更新日時を使用）
@@ -363,7 +390,21 @@ fn file_uri_to_path(uri: &str) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
     use std::path::Path;
+
+    #[test]
+    fn format_timestamp_valid_format() {
+        let datetime = Local.with_ymd_and_hms(2024, 1, 2, 3, 4, 5).unwrap();
+        assert_eq!(format_timestamp(datetime, "%Y%m%d"), "20240102");
+    }
+
+    #[test]
+    fn format_timestamp_invalid_specifier_falls_back() {
+        // %Q は chrono に存在しない指定子 → panic せず既定書式にフォールバックすること
+        let datetime = Local.with_ymd_and_hms(2024, 1, 2, 3, 4, 5).unwrap();
+        assert_eq!(format_timestamp(datetime, "%Q"), "2024-01-02");
+    }
 
     #[test]
     fn file_uri_to_path_existing_file() {

--- a/muhenkan-switch-core/src/commands/timestamp_settings.rs
+++ b/muhenkan-switch-core/src/commands/timestamp_settings.rs
@@ -18,9 +18,7 @@ pub fn toggle_position() -> Result<()> {
 
     muhenkan_switch_config::save(&path, &config)?;
 
-    let ts = chrono::Local::now()
-        .format(&config.timestamp.format)
-        .to_string();
+    let ts = super::timestamp::format_timestamp(chrono::Local::now(), &config.timestamp.format);
     let delimiter = &config.timestamp.delimiter;
     let (label, example) = if config.timestamp.position == "after" {
         ("後", format!("FileName{delimiter}{ts}.txt"))


### PR DESCRIPTION
## 概要

Closes #224

不正なタイムスタンプフォーマット文字列（例: `%Q`）が `validate()` を素通りし、`muhenkan-switch-core` の実行時経路（テキスト入力・ファイルリネーム/複製）で `chrono` の `Display` が返す `Err` を `.to_string()` が握り潰さず panic していた問題を修正。

## 変更内容

- `muhenkan-switch-config/src/lib.rs`
  - `validate()` に `chrono::format::StrftimeItems::new(&format)` を走査してフォーマット文字列の妥当性を検証するチェックを追加。`Item::Error` が含まれる場合は日本語エラーメッセージを返す
  - `chrono` を依存に追加（`muhenkan-switch-config/Cargo.toml`）
- `muhenkan-switch-core/src/commands/timestamp.rs`
  - `format_timestamp(datetime, format) -> String` ヘルパーを追加。`write!` でフォーマット結果を捕捉し、失敗時は `eprintln!` で警告した上で安全な既定書式 `%Y-%m-%d` にフォールバックする（AGENTS.md の「外部要因の失敗は警告して続行」方針に合わせた）
  - `run()` の `("copy", None)` 分岐（テキスト入力コンテキストでの現在日時入力）と `file_modified_timestamp()`（ファイルリネーム/複製で使うファイル更新日時の文字列化）の両方をこのヘルパー経由に変更
- `muhenkan-switch-core/src/commands/timestamp_settings.rs`
  - `toggle_position()` の Toast プレビュー生成も同じ `format_timestamp` ヘルパーに統一
- `muhenkan-switch/src/commands.rs` の `validate_timestamp_format` は既に `write!` でエラーを握っており、`validate()` 側の検証（未知指定子の事前検出）と役割が補完し合う形になるため変更不要と確認
- `config/default-*.toml` の `[timestamp] format` コメントに、存在しない指定子は保存時に検証エラーになる旨の注記を追加

## テスト追加

- `muhenkan-switch-config`: `test_validate_invalid_format_specifier`（`%Q` を拒否）、`test_validate_valid_format_specifiers`（`%Y-%m-%d` 等の代表的な有効フォーマットを許可）
- `muhenkan-switch-core`: `format_timestamp_valid_format`、`format_timestamp_invalid_specifier_falls_back`（不正指定子でも panic せず `%Y-%m-%d` にフォールバックすることを確認）

## 検証結果

- `cargo test --workspace` 全 82 件 pass（muhenkan-switch 8 / muhenkan-switch-config 40 / muhenkan-switch-core 34）
- `cargo check --workspace` エラーなし（externalBin 用に `mise run fetch-kanata` 実行、frontend は `npm ci && npm run build` 実行済み）
- 変更対象ファイルは `cargo fmt --check` で追加差分なし（リポジトリ内の既存フォーマット崩れは本 PR の変更と無関係）