### PR TITLE
frontend の重複コード共通化 (picker モーダル / updater / プリセット切替)

### DIFF
--- a/muhenkan-switch/frontend/src/forms/apps.ts
+++ b/muhenkan-switch/frontend/src/forms/apps.ts
@@ -3,6 +3,7 @@ import { invoke } from '../lib/tauri';
 import { getConfig, getAppPresets } from '../lib/state';
 import { createDispatchKeySelect } from '../lib/dispatch-key';
 import { escapeHtml } from '../lib/utils';
+import { createPickerModal } from '../lib/picker-modal';
 import type { AppEntry } from '../lib/config';
 import type { CollectedConfig } from '../lib/config-io';
 import type { ProcessInfo } from '../lib/ipc-types';
@@ -151,31 +152,9 @@ export async function showProcessPicker(): Promise<string | null> {
     return null;
   }
 
-  return new Promise<string | null>((resolve) => {
-    const overlay = document.createElement('div');
-    overlay.className = 'modal-overlay';
-    overlay.innerHTML = `
-      <div class="modal">
-        <div class="modal-header">プロセスを選択</div>
-        <div class="modal-body">
-          <input type="text" class="modal-search" placeholder="フィルター...">
-          <ul class="modal-list"></ul>
-        </div>
-        <div class="modal-footer">
-          <button class="btn-cancel">キャンセル</button>
-        </div>
-      </div>
-    `;
-
-    const list = overlay.querySelector<HTMLUListElement>('.modal-list');
-    const searchInput = overlay.querySelector<HTMLInputElement>('.modal-search');
-    if (!list || !searchInput) {
-      resolve(null);
-      return;
-    }
-
-    function renderProcessList(filter = ''): void {
-      if (!list) return;
+  return createPickerModal<string>({
+    title: 'プロセスを選択',
+    renderList: (list, filter, select) => {
       list.innerHTML = '';
       const filtered = processes.filter((p) => p.name.toLowerCase().includes(filter.toLowerCase()));
       for (const p of filtered) {
@@ -187,39 +166,11 @@ export async function showProcessPicker(): Promise<string | null> {
           if (name.toLowerCase().endsWith('.exe')) {
             name = name.slice(0, -4);
           }
-          close(name);
+          select(name);
         });
         list.appendChild(li);
       }
-    }
-
-    searchInput.addEventListener('input', (e) => {
-      const target = e.target as HTMLInputElement;
-      renderProcessList(target.value);
-    });
-
-    function close(result: string | null): void {
-      overlay.remove();
-      document.removeEventListener('keydown', onKeydown);
-      resolve(result);
-    }
-
-    overlay
-      .querySelector<HTMLButtonElement>('.btn-cancel')
-      ?.addEventListener('click', () => close(null));
-
-    overlay.addEventListener('click', (e) => {
-      if (e.target === overlay) close(null);
-    });
-
-    function onKeydown(e: KeyboardEvent): void {
-      if (e.key === 'Escape') close(null);
-    }
-    document.addEventListener('keydown', onKeydown);
-
-    renderProcessList();
-    document.body.appendChild(overlay);
-    searchInput.focus();
+    },
   });
 }
 

--- a/muhenkan-switch/frontend/src/forms/general.ts
+++ b/muhenkan-switch/frontend/src/forms/general.ts
@@ -53,25 +53,28 @@ function hideUpdateBadge(): void {
   document.getElementById('footer-update')?.classList.add('hidden');
 }
 
-// ── Updater (installer: Windows / tauri-plugin-updater) ──
-async function checkForUpdate(silent = true): Promise<void> {
+// ── Updater 共通スケルトン ──
+// 「バージョン取得 → 見つかればバッジ提示 (+ 非 silent 時は run 実行) → 見つからなければ
+// バッジ非表示 (+ 非 silent 時は最新メッセージ)」の分岐は installer / script 共通。
+// 取得元 (fetchUpdate) と実際の更新処理 (run) だけが実装ごとに異なるため引数化する。
+interface UpdateFound {
+  /** バッジ・ダイアログに表示するバージョン文字列 */
+  version: string;
+  /** 実際の更新処理 (バッジクリック or 非 silent 時の即時実行の両方から呼ばれる) */
+  run: () => Promise<void>;
+}
+
+async function runUpdateCheck(
+  silent: boolean,
+  fetchUpdate: (currentVersion: string) => Promise<UpdateFound | null>,
+): Promise<void> {
   try {
     const currentVersion = await invoke<string>('get_app_version');
-    const update = await invoke<UpdateInfo | null>('check_update');
-    if (update) {
-      const run = async (): Promise<void> => {
-        if (
-          await ask(`現在: v${currentVersion} → 最新: v${update.version}\nアップデートしますか？`, {
-            title: 'アップデート',
-          })
-        ) {
-          await invoke('stop_kanata');
-          await invoke('install_update');
-        }
-      };
-      showUpdateBadge(update.version, run);
+    const found = await fetchUpdate(currentVersion);
+    if (found) {
+      showUpdateBadge(found.version, found.run);
       // トレイからの手動チェックは即ダイアログ。サイレント時はバッジのみ。
-      if (!silent) await run();
+      if (!silent) await found.run();
     } else {
       hideUpdateBadge();
       if (!silent) await message(`v${currentVersion} は最新です。`, { title: 'アップデート' });
@@ -86,13 +89,33 @@ async function checkForUpdate(silent = true): Promise<void> {
   }
 }
 
+// ── Updater (installer: Windows / tauri-plugin-updater) ──
+async function checkForUpdate(silent = true): Promise<void> {
+  await runUpdateCheck(silent, async (currentVersion) => {
+    const update = await invoke<UpdateInfo | null>('check_update');
+    if (!update) return null;
+    return {
+      version: update.version,
+      run: async () => {
+        if (
+          await ask(`現在: v${currentVersion} → 最新: v${update.version}\nアップデートしますか？`, {
+            title: 'アップデート',
+          })
+        ) {
+          await invoke('stop_kanata');
+          await invoke('install_update');
+        }
+      },
+    };
+  });
+}
+
 // ── Updater (script: Linux/macOS / GitHub API + terminal spawn) ──
 const GITHUB_LATEST_RELEASE_URL =
   'https://api.github.com/repos/kimushun1101/muhenkan-switch/releases/latest';
 
 async function checkGithubLatestRelease(silent = true): Promise<void> {
-  try {
-    const currentVersion = await invoke<string>('get_app_version');
+  await runUpdateCheck(silent, async (currentVersion) => {
     const res = await fetch(GITHUB_LATEST_RELEASE_URL);
     if (!res.ok) {
       throw new Error(`GitHub API エラー: HTTP ${res.status}`);
@@ -103,43 +126,30 @@ async function checkGithubLatestRelease(silent = true): Promise<void> {
     }
     const latestVersion = release.tag_name.replace(/^v/, '');
 
-    if (latestVersion === currentVersion) {
-      hideUpdateBadge();
-      if (!silent) {
-        await message(`v${currentVersion} は最新です。`, { title: 'アップデート' });
-      }
-      return;
-    }
+    if (latestVersion === currentVersion) return null;
 
-    const run = async (): Promise<void> => {
-      const proceed = await ask(
-        `現在: v${currentVersion} → 最新: v${latestVersion}\n\n` +
-          `ターミナルでアップデートを実行しますか？`,
-        { title: 'アップデート' },
-      );
-      if (!proceed) return;
-
-      try {
-        await invoke('spawn_update_terminal');
-      } catch (e) {
-        await message(
-          `ターミナルの起動に失敗しました:\n${String(e)}\n\n` +
-            `手動で update.sh / update-macos.sh を実行してください。`,
-          { title: 'エラー', kind: 'error' },
+    return {
+      version: latestVersion,
+      run: async () => {
+        const proceed = await ask(
+          `現在: v${currentVersion} → 最新: v${latestVersion}\n\n` +
+            `ターミナルでアップデートを実行しますか？`,
+          { title: 'アップデート' },
         );
-      }
+        if (!proceed) return;
+
+        try {
+          await invoke('spawn_update_terminal');
+        } catch (e) {
+          await message(
+            `ターミナルの起動に失敗しました:\n${String(e)}\n\n` +
+              `手動で update.sh / update-macos.sh を実行してください。`,
+            { title: 'エラー', kind: 'error' },
+          );
+        }
+      },
     };
-    showUpdateBadge(latestVersion, run);
-    // トレイからの手動チェックは即ダイアログ。サイレント時はバッジのみ。
-    if (!silent) await run();
-  } catch (e) {
-    console.error('[updater]', e);
-    if (!silent)
-      await message('アップデート確認に失敗しました:\n' + String(e), {
-        title: 'エラー',
-        kind: 'error',
-      });
-  }
+  });
 }
 
 export interface InitGeneralFormOptions {

--- a/muhenkan-switch/frontend/src/forms/search.ts
+++ b/muhenkan-switch/frontend/src/forms/search.ts
@@ -3,6 +3,7 @@ import { getConfig, getSearchPresets } from '../lib/state';
 import type { SearchPreset } from '../lib/state';
 import { createDispatchKeySelect } from '../lib/dispatch-key';
 import { escapeHtml } from '../lib/utils';
+import { createPickerModal } from '../lib/picker-modal';
 import type { SearchEntry } from '../lib/config';
 import type { CollectedConfig } from '../lib/config-io';
 
@@ -66,32 +67,10 @@ export function addSearchRow(container: HTMLElement, name = '', url = '', dispat
 
 // ── Search preset picker modal ──
 export function showSearchPicker(): Promise<SearchPreset | null> {
-  return new Promise<SearchPreset | null>((resolve) => {
-    const SEARCH_PRESETS = getSearchPresets();
-    const overlay = document.createElement('div');
-    overlay.className = 'modal-overlay';
-    overlay.innerHTML = `
-      <div class="modal">
-        <div class="modal-header">検索サービスを選択</div>
-        <div class="modal-body">
-          <input type="text" class="modal-search" placeholder="フィルター...">
-          <ul class="modal-list"></ul>
-        </div>
-        <div class="modal-footer">
-          <button class="btn-cancel">キャンセル</button>
-        </div>
-      </div>
-    `;
-
-    const list = overlay.querySelector<HTMLUListElement>('.modal-list');
-    const filterInput = overlay.querySelector<HTMLInputElement>('.modal-search');
-    if (!list || !filterInput) {
-      resolve(null);
-      return;
-    }
-
-    function renderList(filter = ''): void {
-      if (!list) return;
+  const SEARCH_PRESETS = getSearchPresets();
+  return createPickerModal<SearchPreset>({
+    title: '検索サービスを選択',
+    renderList: (list, filter, select) => {
       list.innerHTML = '';
       const lf = filter.toLowerCase();
       for (const [category, services] of Object.entries(SEARCH_PRESETS)) {
@@ -106,38 +85,11 @@ export function showSearchPicker(): Promise<SearchPreset | null> {
         for (const svc of filtered) {
           const li = document.createElement('li');
           li.textContent = svc.label;
-          li.addEventListener('click', () => close(svc));
+          li.addEventListener('click', () => select(svc));
           list.appendChild(li);
         }
       }
-    }
-
-    filterInput.addEventListener('input', (e) => {
-      const target = e.target as HTMLInputElement;
-      renderList(target.value);
-    });
-
-    function close(result: SearchPreset | null): void {
-      overlay.remove();
-      document.removeEventListener('keydown', onKeydown);
-      resolve(result);
-    }
-
-    overlay
-      .querySelector<HTMLButtonElement>('.btn-cancel')
-      ?.addEventListener('click', () => close(null));
-    overlay.addEventListener('click', (e) => {
-      if (e.target === overlay) close(null);
-    });
-
-    function onKeydown(e: KeyboardEvent): void {
-      if (e.key === 'Escape') close(null);
-    }
-    document.addEventListener('keydown', onKeydown);
-
-    renderList();
-    document.body.appendChild(overlay);
-    filterInput.focus();
+    },
   });
 }
 

--- a/muhenkan-switch/frontend/src/forms/timestamp.ts
+++ b/muhenkan-switch/frontend/src/forms/timestamp.ts
@@ -4,39 +4,33 @@ import { getConfig } from '../lib/state';
 import type { CollectedConfig } from '../lib/config-io';
 import { requireEl } from '../lib/dom-utils';
 
+// 設定値がプリセット一覧の値と一致すればそのプリセットを選択し custom 入力を隠す。
+// 一致しなければ 'custom' を選択して custom 入力にその値を反映して表示する
+// (renderTimestamp の format / delimiter 初期化で使う same-shape 処理を集約)。
+function applyPresetOrCustom(presetId: string, customId: string, value: string): void {
+  const presetEl = requireEl<HTMLSelectElement>(presetId);
+  const customEl = requireEl<HTMLInputElement>(customId);
+  const matched = Array.from(presetEl.options).find((o) => o.value === value);
+  if (matched) {
+    presetEl.value = value;
+    customEl.classList.add('hidden');
+  } else {
+    presetEl.value = 'custom';
+    customEl.value = value;
+    customEl.classList.remove('hidden');
+  }
+}
+
 export function renderTimestamp(): void {
   const config = getConfig();
   if (!config) return;
 
-  // Format
-  const formatPreset = requireEl<HTMLSelectElement>('ts-format-preset');
-  const formatCustom = requireEl<HTMLInputElement>('ts-format-custom');
-  const format = config.timestamp.format;
-
-  const formatOption = Array.from(formatPreset.options).find((o) => o.value === format);
-  if (formatOption) {
-    formatPreset.value = format;
-    formatCustom.classList.add('hidden');
-  } else {
-    formatPreset.value = 'custom';
-    formatCustom.value = format;
-    formatCustom.classList.remove('hidden');
-  }
-
-  // Delimiter
-  const delimPreset = requireEl<HTMLSelectElement>('ts-delimiter-preset');
-  const delimCustom = requireEl<HTMLInputElement>('ts-delimiter-custom');
-  const delimiter = config.timestamp.delimiter ?? '_';
-
-  const delimOption = Array.from(delimPreset.options).find((o) => o.value === delimiter);
-  if (delimOption) {
-    delimPreset.value = delimiter;
-    delimCustom.classList.add('hidden');
-  } else {
-    delimPreset.value = 'custom';
-    delimCustom.value = delimiter;
-    delimCustom.classList.remove('hidden');
-  }
+  applyPresetOrCustom('ts-format-preset', 'ts-format-custom', config.timestamp.format);
+  applyPresetOrCustom(
+    'ts-delimiter-preset',
+    'ts-delimiter-custom',
+    config.timestamp.delimiter ?? '_',
+  );
 
   // Position
   const posRadio = document.querySelector<HTMLInputElement>(
@@ -94,38 +88,30 @@ export async function updateTimestampPreview(): Promise<void> {
   }
 }
 
+// preset select の change で custom 入力欄の表示/非表示 (+ フォーカス) を切り替え、
+// custom 入力の input でプレビュー更新をトリガーする配線
+// (initTimestampForm の format / delimiter 初期化で使う same-shape 処理を集約)。
+function initPresetCustomToggle(presetId: string, customId: string): void {
+  requireEl<HTMLSelectElement>(presetId).addEventListener('change', (e) => {
+    const target = e.target as HTMLSelectElement;
+    const customInput = requireEl<HTMLInputElement>(customId);
+    if (target.value === 'custom') {
+      customInput.classList.remove('hidden');
+      customInput.focus();
+    } else {
+      customInput.classList.add('hidden');
+    }
+    void updateTimestampPreview();
+  });
+
+  requireEl<HTMLInputElement>(customId).addEventListener('input', () => {
+    void updateTimestampPreview();
+  });
+}
+
 export function initTimestampForm(): void {
-  requireEl<HTMLSelectElement>('ts-format-preset').addEventListener('change', (e) => {
-    const target = e.target as HTMLSelectElement;
-    const customInput = requireEl<HTMLInputElement>('ts-format-custom');
-    if (target.value === 'custom') {
-      customInput.classList.remove('hidden');
-      customInput.focus();
-    } else {
-      customInput.classList.add('hidden');
-    }
-    void updateTimestampPreview();
-  });
-
-  requireEl<HTMLInputElement>('ts-format-custom').addEventListener('input', () => {
-    void updateTimestampPreview();
-  });
-
-  requireEl<HTMLSelectElement>('ts-delimiter-preset').addEventListener('change', (e) => {
-    const target = e.target as HTMLSelectElement;
-    const customInput = requireEl<HTMLInputElement>('ts-delimiter-custom');
-    if (target.value === 'custom') {
-      customInput.classList.remove('hidden');
-      customInput.focus();
-    } else {
-      customInput.classList.add('hidden');
-    }
-    void updateTimestampPreview();
-  });
-
-  requireEl<HTMLInputElement>('ts-delimiter-custom').addEventListener('input', () => {
-    void updateTimestampPreview();
-  });
+  initPresetCustomToggle('ts-format-preset', 'ts-format-custom');
+  initPresetCustomToggle('ts-delimiter-preset', 'ts-delimiter-custom');
 
   document.querySelectorAll<HTMLInputElement>('input[name="ts-position"]').forEach((radio) => {
     radio.addEventListener('change', () => void updateTimestampPreview());

--- a/muhenkan-switch/frontend/src/lib/picker-modal.ts
+++ b/muhenkan-switch/frontend/src/lib/picker-modal.ts
@@ -1,0 +1,79 @@
+// ── Generic filterable picker modal ──
+// forms/apps.ts の showProcessPicker と forms/search.ts の showSearchPicker で
+// ほぼ同一だった overlay 生成 / .modal 骨格 / フィルタ入力 / close() /
+// overlay クリック・Escape での閉じる処理を集約 (Issue #229)。
+// 一覧の描画方法 (フラット / グループ化) と選択後の後処理は呼び出し側に委ねるため、
+// DOM 構造・クラス名・フォーカス挙動は元実装から変更していない。
+
+export interface PickerModalOptions<T> {
+  /** .modal-header に表示するタイトル (静的文字列想定。エスケープ不要) */
+  title: string;
+  /**
+   * `.modal-list` の中身を再描画するコールバック。
+   * `filter` はフィルタ入力欄の現在値、`select` は項目クリック時に呼ぶと
+   * モーダルを閉じてその値で Promise を解決する。
+   */
+  renderList: (list: HTMLUListElement, filter: string, select: (result: T) => void) => void;
+}
+
+export function createPickerModal<T>({
+  title,
+  renderList,
+}: PickerModalOptions<T>): Promise<T | null> {
+  return new Promise<T | null>((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+    overlay.innerHTML = `
+      <div class="modal">
+        <div class="modal-header">${title}</div>
+        <div class="modal-body">
+          <input type="text" class="modal-search" placeholder="フィルター...">
+          <ul class="modal-list"></ul>
+        </div>
+        <div class="modal-footer">
+          <button class="btn-cancel">キャンセル</button>
+        </div>
+      </div>
+    `;
+
+    const list = overlay.querySelector<HTMLUListElement>('.modal-list');
+    const searchInput = overlay.querySelector<HTMLInputElement>('.modal-search');
+    if (!list || !searchInput) {
+      resolve(null);
+      return;
+    }
+
+    function close(result: T | null): void {
+      overlay.remove();
+      document.removeEventListener('keydown', onKeydown);
+      resolve(result);
+    }
+
+    function render(filter = ''): void {
+      if (!list) return;
+      renderList(list, filter, close);
+    }
+
+    searchInput.addEventListener('input', (e) => {
+      const target = e.target as HTMLInputElement;
+      render(target.value);
+    });
+
+    overlay
+      .querySelector<HTMLButtonElement>('.btn-cancel')
+      ?.addEventListener('click', () => close(null));
+
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) close(null);
+    });
+
+    function onKeydown(e: KeyboardEvent): void {
+      if (e.key === 'Escape') close(null);
+    }
+    document.addEventListener('keydown', onKeydown);
+
+    render();
+    document.body.appendChild(overlay);
+    searchInput.focus();
+  });
+}


### PR DESCRIPTION
## Summary

Issue #229 の指摘に沿って、フロントエンドの重複コードを共通化するリファクタリング。**挙動は一切変更していない**（DOM 構造・クラス名・フォーカス/デバウンス挙動・エラーメッセージ文言・分岐条件はすべて維持）。

1. **picker モーダル共通化**: `forms/apps.ts` の `showProcessPicker` と `forms/search.ts` の `showSearchPicker` で重複していた overlay 生成・`.modal` innerHTML 骨格・フィルタ input ハンドラ・`close()`・overlay クリック / Escape で閉じる処理を `lib/picker-modal.ts` の `createPickerModal({ title, renderList })` に抽出。一覧の描画方法 (フラット vs グループ化) と選択後の後処理 (exe 拡張子除去など) は呼び出し側のコールバックに委譲。
2. **updater 共通化**: `forms/general.ts` の `checkForUpdate` / `checkGithubLatestRelease` で重複していた「バージョン取得 → 見つかればバッジ提示 (+非 silent 時は run 実行) → 見つからなければバッジ非表示 (+非 silent 時は最新メッセージ)」のスケルトンを `runUpdateCheck(silent, fetchUpdate)` に集約。バージョン取得元・実行処理 (`run`) だけを各関数側で引数化。
3. **プリセット custom 切替共通化**: `forms/timestamp.ts` の format / delimiter の same-shape 処理を 2 つのヘルパーに集約。
   - `applyPresetOrCustom(presetId, customId, value)`: renderTimestamp の初期化ロジック (値がプリセットに一致すれば選択、しなければ custom を選択して値を反映)
   - `initPresetCustomToggle(presetId, customId)`: initTimestampForm の change/input イベント配線 (custom 選択時に入力欄を表示 + フォーカス)

   ※ issue の修正案では単一ヘルパー `(presetId, customId, value)` を想定していましたが、render 時の「値がプリセット一覧に一致するか」判定と change ハンドラ時の「ユーザーが 'custom' を選んだか」判定は意味的に異なり（前者を後者に流用すると 'custom' という値そのものがプリセット一覧の選択肢と一致してしまい、表示/非表示が反転する）、1 つに統合すると挙動が変わってしまうため 2 つの薄いヘルパーに分けています。

## 削減行数

既存 4 ファイルで net -101 行（+109/-210）、新規 `lib/picker-modal.ts` (+79 行) を差し引いた全体では net **-22 行**。

```
 muhenkan-switch/frontend/src/forms/apps.ts       |  61 ++----------
 muhenkan-switch/frontend/src/forms/general.ts    | 114 ++++++++++++-----------
 muhenkan-switch/frontend/src/forms/search.ts     |  62 ++----------
 muhenkan-switch/frontend/src/forms/timestamp.ts  |  82 +++++++---------
 muhenkan-switch/frontend/src/lib/picker-modal.ts |  79 ++++++++++++++++
 5 files changed, 188 insertions(+), 210 deletions(-)
```

## 挙動維持の自己レビュー

- **picker モーダル**: `createPickerModal` の DOM 構造・class 名 (`modal-overlay`/`modal`/`modal-header`/`modal-body`/`modal-search`/`modal-list`/`modal-footer`/`btn-cancel`) は元コードと一字一句同一。`showProcessPicker` は取得失敗時に modal を開かず `null` を直接返す分岐を維持。`showSearchPicker` の `getSearchPresets()` 呼び出しタイミングも、元は Promise executor 内 (同期実行) だったのを `createPickerModal` 呼び出し前に移動しているが、どちらも同一 tick の同期実行のため呼び出しタイミングは実質不変。
- **updater**: `checkForUpdate` / `checkGithubLatestRelease` とも、`run()` 内部の try/catch (spawn 失敗時のローカルなエラーハンドリング) はそのままコールバック内に保持しているため、外側の `runUpdateCheck` の catch には伝播しない元の挙動を維持。バッジ表示 → 非 silent 時の即時実行、という順序・条件分岐も同一。
- **timestamp.ts**: `applyPresetOrCustom` は `formatOption`/`delimOption` の一致判定ロジックをそのまま関数化。`initPresetCustomToggle` も change/input のイベント配線をそのまま関数化。既存の `timestamp.test.ts` (18 tests) は無変更で全通過、per-file coverage 閾値 (80%) も 100% を維持。

## 検証結果

`muhenkan-switch/frontend` で以下すべて pass:

- `npm run typecheck` ✅ (エラーなし)
- `npm run lint` ✅ (0 problems)
- `npm run format:check` ✅
- `npm run test` ✅ (3 test files / 34 tests pass、`timestamp.ts` per-file coverage 100%)
- `npm run build` ✅

Closes #229