### PR TITLE
fix: 自動起動のトレイ⇔GUI 双方向同期を実装

### DIFF
--- a/muhenkan-switch/frontend/src/forms/general.ts
+++ b/muhenkan-switch/frontend/src/forms/general.ts
@@ -23,11 +23,16 @@ function updateKanataUI(running: boolean): void {
 }
 
 // ── Autostart checkbox ──
-export async function loadAutostart(): Promise<void> {
+// トレイの CheckMenuItem と GUI チェックボックスは同じ自動起動状態を指すため、
+// どちらから変更しても 'autostart-changed' イベント (実状態) でもう一方に反映する。
+function setAutostartCheckbox(enabled: boolean): void {
   const autostartCheckbox = document.getElementById('opt-autostart') as HTMLInputElement | null;
-  if (!autostartCheckbox) return;
+  if (autostartCheckbox) autostartCheckbox.checked = enabled;
+}
+
+export async function loadAutostart(): Promise<void> {
   try {
-    autostartCheckbox.checked = await invoke<boolean>('get_autostart_enabled');
+    setAutostartCheckbox(await invoke<boolean>('get_autostart_enabled'));
   } catch (e) {
     console.error('自動起動状態の取得に失敗:', e);
   }
@@ -209,6 +214,8 @@ export function initGeneralForm({ renderConfig }: InitGeneralFormOptions): void 
   });
 
   // ── Autostart checkbox listener ──
+  // 実際の反映は 'autostart-changed' イベント経由 (バックエンドが実状態を読み直して
+  // emit する) で行うため、ここでは呼び出しの成否をログするだけでよい。
   const autostartCheckbox = document.getElementById('opt-autostart') as HTMLInputElement | null;
   if (autostartCheckbox) {
     autostartCheckbox.addEventListener('change', async () => {
@@ -216,10 +223,14 @@ export function initGeneralForm({ renderConfig }: InitGeneralFormOptions): void 
         await invoke('set_autostart_enabled', { enabled: autostartCheckbox.checked });
       } catch (e) {
         console.error('自動起動の切り替えに失敗:', e);
-        autostartCheckbox.checked = !autostartCheckbox.checked;
       }
     });
   }
+
+  // ── Autostart 状態同期イベント (トレイ⇔GUI 双方向) ──
+  void listen<boolean>('autostart-changed', (event) => {
+    setAutostartCheckbox(event.payload);
+  });
 
   // ── Kanata status event ──
   void listen<boolean>('kanata-status-changed', (event) => {

--- a/muhenkan-switch/src/commands.rs
+++ b/muhenkan-switch/src/commands.rs
@@ -386,11 +386,15 @@ pub fn get_autostart_enabled(app: tauri::AppHandle) -> Result<bool, String> {
 pub fn set_autostart_enabled(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
     use tauri_plugin_autostart::ManagerExt;
     let autostart = app.autolaunch();
-    if enabled {
+    let result = if enabled {
         autostart.enable().map_err(|e| e.to_string())
     } else {
         autostart.disable().map_err(|e| e.to_string())
-    }
+    };
+    // enable/disable の成否に関わらず実状態を読み直し、トレイ CheckMenuItem と
+    // GUI チェックボックスの両方を同期させる (autostart-changed イベント emit)。
+    crate::tray::sync_autostart_state(&app);
+    result
 }
 
 // ── Install type detection ──

--- a/muhenkan-switch/src/tray.rs
+++ b/muhenkan-switch/src/tray.rs
@@ -1,9 +1,34 @@
 use std::sync::Mutex;
 use std::time::Instant;
 
-use tauri::menu::{CheckMenuItemBuilder, MenuBuilder, MenuItemBuilder, PredefinedMenuItem};
+use tauri::menu::{
+    CheckMenuItem, CheckMenuItemBuilder, MenuBuilder, MenuItemBuilder, PredefinedMenuItem,
+};
 use tauri::tray::TrayIconBuilder;
 use tauri::{AppHandle, Emitter, Manager};
+
+/// トレイの「ログイン時に自動起動」チェック項目ハンドル。
+/// トレイクリック / GUI チェックボックスのどちらから状態を変更しても、
+/// もう一方の表示を実状態 (`autolaunch().is_enabled()`) に揃えるため、
+/// app state として保持しておき `sync_autostart_state` から参照する。
+pub struct AutostartMenuHandle(pub CheckMenuItem<tauri::Wry>);
+
+/// 自動起動の実状態を読み直し、トレイ CheckMenuItem の表示 (`set_checked`) と
+/// GUI チェックボックスの両方を同期させる。
+///
+/// トレイの「自動起動」クリック時、および `set_autostart_enabled` コマンドの
+/// 実行後に呼ぶ。enable/disable が失敗した場合でも実状態を読み直すため、
+/// 表示と実状態がズレることはない。
+pub fn sync_autostart_state(app: &AppHandle) {
+    use tauri_plugin_autostart::ManagerExt;
+    let enabled = app.autolaunch().is_enabled().unwrap_or(false);
+    if let Some(state) = app.try_state::<AutostartMenuHandle>() {
+        if let Err(e) = state.0.set_checked(enabled) {
+            eprintln!("[tray] 自動起動メニューの表示更新に失敗: {:#}", e);
+        }
+    }
+    let _ = app.emit("autostart-changed", enabled);
+}
 
 pub fn setup(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     let handle = app.handle();
@@ -14,11 +39,15 @@ pub fn setup(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn build_tray(handle: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
+    use tauri_plugin_autostart::ManagerExt;
+
     let settings_item = MenuItemBuilder::with_id("settings", "設定...").build(handle)?;
     let sep1 = PredefinedMenuItem::separator(handle)?;
-    let autostart_item =
-        CheckMenuItemBuilder::with_id("autostart", "ログイン時に自動起動")
-            .build(handle)?;
+    let autostart_enabled = handle.autolaunch().is_enabled().unwrap_or(false);
+    let autostart_item = CheckMenuItemBuilder::with_id("autostart", "ログイン時に自動起動")
+        .checked(autostart_enabled)
+        .build(handle)?;
+    handle.manage(AutostartMenuHandle(autostart_item.clone()));
     let open_dir_item = MenuItemBuilder::with_id("open_dir", "インストール先を開く")
         .build(handle)?;
     // インストーラー版 / スクリプト版どちらでも表示する。
@@ -62,12 +91,18 @@ fn build_tray(handle: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                 "autostart" => {
                     use tauri_plugin_autostart::ManagerExt;
                     if let Ok(enabled) = app.autolaunch().is_enabled() {
-                        if enabled {
-                            let _ = app.autolaunch().disable();
+                        let result = if enabled {
+                            app.autolaunch().disable()
                         } else {
-                            let _ = app.autolaunch().enable();
+                            app.autolaunch().enable()
+                        };
+                        if let Err(e) = result {
+                            eprintln!("[tray] 自動起動の切り替えに失敗: {:#}", e);
                         }
                     }
+                    // クリックで muda がチェック表示を自動トグルするため、
+                    // 実状態を読み直して tray / GUI 双方を確定させる。
+                    sync_autostart_state(app);
                 }
                 "quit" => {
                     use crate::kanata::KanataManager;


### PR DESCRIPTION
## 概要

トレイ「ログイン時に自動起動」の CheckMenuItem と GUI 設定タブのチェックボックスが同期していなかった問題 (#216) を修正。

- `muhenkan-switch/src/tray.rs`
  - `CheckMenuItemBuilder` 構築時に `.checked(autolaunch().is_enabled())` で初期状態を反映
  - トレイの CheckMenuItem ハンドルを `AutostartMenuHandle` として `app.manage()` に保持
  - `sync_autostart_state(app)` を追加: `autolaunch().is_enabled()` で実状態を読み直し、tray の `set_checked` と `autostart-changed` イベント emit の両方を行う共通処理
  - トレイ「自動起動」クリック時、enable/disable 実行後に必ず `sync_autostart_state` を呼び、muda が自動トグルした表示を実状態で確定させる（enable/disable 失敗時も表示がズレない）
- `muhenkan-switch/src/commands.rs`
  - `set_autostart_enabled` コマンドで enable/disable 実行後、成否に関わらず `sync_autostart_state(&app)` を呼んで tray / GUI を同期
- `muhenkan-switch/frontend/src/forms/general.ts`
  - `'autostart-changed'` イベントを購読し、実状態でチェックボックスを更新する `setAutostartCheckbox()` を追加
  - 変更ハンドラでの手動チェックボックス反転処理を削除（イベント経由の同期に一本化）

変更経路が集約されたことで、トレイ・GUI どちらから変更しても双方の表示が実際の自動起動設定と一致するようになる。

Closes #216

## 検証結果

- フロントエンド (`muhenkan-switch/frontend/`)
  - `npm ci` / `npm run typecheck` / `npm run lint` / `npm run format:check` / `npm run test`（coverage 含む） / `npm run build` すべて pass
  - `general.ts` は `vitest.config.ts` の coverage whitelist 対象外のため新規テスト追加は必須ではなく、追加していない
- バックエンド (Rust)
  - `mise trust && mise run fetch-kanata` で kanata バイナリを用意し、`muhenkan-switch-core` をビルドして externalBin を配置した上で
  - `cargo check -p muhenkan-switch` pass
  - `cargo test --workspace` 全 78 件 pass
  - `cargo clippy -p muhenkan-switch --no-deps` の警告 3 件は今回の変更箇所と無関係な既存コード（`commands.rs:633,284`, `main.rs:35`）

## GUI 実機での確認手順（レビュー用）

1. アプリを起動し、自動起動が無効な状態でトレイアイコンを右クリック → 「ログイン時に自動起動」のチェックが実際の設定 (OFF) と一致していることを確認
2. トレイの「ログイン時に自動起動」をクリックして ON にする → GUI の設定タブを開き、チェックボックスが ON になっていることを確認
3. GUI のチェックボックスを OFF にする → トレイメニューを開き直し、チェックが OFF に更新されていることを確認
4. アプリを再起動し、トレイの初期表示が実際の自動起動設定と一致していることを確認（起動直後、GUI を開く前でも tray 上のチェック状態が正しいこと）