### PR TITLE
fix(install): API レート制限に依存しないバージョン取得経路を追加

### DIFF
--- a/scripts/install/get.ps1
+++ b/scripts/install/get.ps1
@@ -25,27 +25,72 @@ Write-Host ""
 # ── TLS 1.2 を有効化 ──
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
+# ── GitHub API フォールバック用ヘルパー ──
+# 未認証の GitHub API は 60 req/時/IP のレート制限があるため、通常はリダイレクト
+# 経由 (下記) でタグを取得する。API はリダイレクト経路が失敗した場合のみ使う。
+function Get-MuhenkanReleaseInfo {
+    param([string]$Repo)
+    try {
+        return Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -UseBasicParsing
+    } catch {
+        Write-Host "[ERROR] 最新バージョンの取得に失敗しました: $_" -ForegroundColor Red
+        Write-Host "        ネットワーク接続を確認してください。" -ForegroundColor Red
+        exit 1
+    }
+}
+
+function Resolve-MuhenkanAsset {
+    param($ReleaseInfo, [string]$Pattern)
+    $found = $ReleaseInfo.assets | Where-Object { $_.name -like $Pattern } | Select-Object -First 1
+    if (-not $found) {
+        Write-Host "[ERROR] インストーラー ($Pattern) がリリースに見つかりませんでした。" -ForegroundColor Red
+        exit 1
+    }
+    return $found
+}
+
 # ── 最新バージョンを取得 ──
+# 1. releases/latest への HTTP リダイレクト先 (Location ヘッダ) からタグ名を取得する。
+#    API 不要・レート制限なしの経路。AllowAutoRedirect を無効にすると、
+#    HttpWebRequest はリダイレクト応答をそのまま返す (3xx は例外にならない)。
 Write-Host "最新バージョンを確認しています..."
+
+$latestTag = $null
 try {
-    $releaseInfo = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO/releases/latest" -UseBasicParsing
-    $latestTag = $releaseInfo.tag_name
+    $request = [System.Net.WebRequest]::Create("https://github.com/$REPO/releases/latest")
+    $request.Method = "HEAD"
+    $request.AllowAutoRedirect = $false
+    $request.Timeout = 10000
+    $response = $request.GetResponse()
+    $location = $response.Headers["Location"]
+    $response.Close()
 } catch {
-    Write-Host "[ERROR] 最新バージョンの取得に失敗しました: $_" -ForegroundColor Red
-    Write-Host "        ネットワーク接続を確認してください。" -ForegroundColor Red
-    exit 1
+    $location = $null
 }
 
-Write-Host "最新バージョン: $latestTag"
-
-# ── ダウンロードする setup.exe を特定 ──
-$asset = $releaseInfo.assets | Where-Object { $_.name -like $ASSET_PATTERN } | Select-Object -First 1
-if (-not $asset) {
-    Write-Host "[ERROR] インストーラー ($ASSET_PATTERN) がリリースに見つかりませんでした。" -ForegroundColor Red
-    exit 1
+if ($location -and ($location -match '/releases/tag/(v[0-9][^/]+)$')) {
+    $latestTag = $Matches[1]
 }
-$ASSET_NAME = $asset.name
-$downloadUrl = $asset.browser_download_url
+
+$releaseInfo = $null
+
+if ($latestTag) {
+    Write-Host "最新バージョン: $latestTag"
+    # NSIS 既定の命名規則 (<productName>_<version>_x64-setup.exe) からアセット名を予測する。
+    $versionNumber = $latestTag -replace '^v', ''
+    $ASSET_NAME = "muhenkan-switch_${versionNumber}_x64-setup.exe"
+    $downloadUrl = "https://github.com/$REPO/releases/latest/download/$ASSET_NAME"
+} else {
+    # 2. フォールバック: GitHub API (未認証 60 req/時/IP のレート制限あり)
+    Write-Host "[WARN] リダイレクトでのバージョン取得に失敗したため GitHub API を使用します。" -ForegroundColor Yellow
+    $releaseInfo = Get-MuhenkanReleaseInfo -Repo $REPO
+    $latestTag = $releaseInfo.tag_name
+    Write-Host "最新バージョン: $latestTag"
+
+    $asset = Resolve-MuhenkanAsset -ReleaseInfo $releaseInfo -Pattern $ASSET_PATTERN
+    $ASSET_NAME = $asset.name
+    $downloadUrl = $asset.browser_download_url
+}
 
 # ── ダウンロード ──
 Write-Host ""
@@ -57,8 +102,27 @@ try {
     Invoke-WebRequest -Uri $downloadUrl -OutFile $tempExe -UseBasicParsing
     Write-Host "[OK] ダウンロード完了" -ForegroundColor Green
 } catch {
-    Write-Host "[ERROR] ダウンロードに失敗しました: $_" -ForegroundColor Red
-    exit 1
+    if (-not $releaseInfo) {
+        # 予測したアセット名が実際には存在しなかった可能性があるため、
+        # GitHub API で正確なアセット情報を取得して 1 度だけ再試行する。
+        Write-Host "[WARN] 想定アセットのダウンロードに失敗したため GitHub API で確認します..." -ForegroundColor Yellow
+        $releaseInfo = Get-MuhenkanReleaseInfo -Repo $REPO
+        $asset = Resolve-MuhenkanAsset -ReleaseInfo $releaseInfo -Pattern $ASSET_PATTERN
+        $ASSET_NAME = $asset.name
+        $downloadUrl = $asset.browser_download_url
+        $tempExe = Join-Path $env:TEMP $ASSET_NAME
+
+        try {
+            Invoke-WebRequest -Uri $downloadUrl -OutFile $tempExe -UseBasicParsing
+            Write-Host "[OK] ダウンロード完了" -ForegroundColor Green
+        } catch {
+            Write-Host "[ERROR] ダウンロードに失敗しました: $_" -ForegroundColor Red
+            exit 1
+        }
+    } else {
+        Write-Host "[ERROR] ダウンロードに失敗しました: $_" -ForegroundColor Red
+        exit 1
+    }
 }
 
 # ── インストール (サイレント) ──

--- a/scripts/install/get.sh
+++ b/scripts/install/get.sh
@@ -47,20 +47,39 @@ case "$OS" in
 esac
 
 # ── 最新バージョンを取得 ──
+# GitHub API (未認証 60 req/時/IP) はレート制限に当たりやすいため、
+# まず releases/latest への HTTP リダイレクト先 (Location ヘッダ) からタグを
+# 取得する経路を優先する (API 不要・レート制限なし)。失敗した場合のみ API に
+# フォールバックする。
 echo ""
 echo "最新バージョンを確認しています..."
 
+latest_tag=""
+
 if command -v curl >/dev/null 2>&1; then
-    api_response=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest")
+    redirect_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "https://github.com/$REPO/releases/latest" 2>/dev/null) || redirect_url=""
 elif command -v wget >/dev/null 2>&1; then
-    api_response=$(wget -qO- "https://api.github.com/repos/$REPO/releases/latest")
+    redirect_url=$(wget --max-redirect=20 --server-response --spider -q -O /dev/null "https://github.com/$REPO/releases/latest" 2>&1 \
+        | grep -i 'Location:' | tail -1 | tr -d '[:space:]') || redirect_url=""
 else
     echo "[ERROR] curl または wget が必要です"
     exit 1
 fi
 
-# jq なしで tag_name を抽出
-latest_tag=$(echo "$api_response" | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/"tag_name"[[:space:]]*:[[:space:]]*"\(.*\)"/\1/')
+case "$redirect_url" in
+    */releases/tag/v[0-9]*) latest_tag=$(echo "$redirect_url" | sed 's#.*/releases/tag/##') ;;
+esac
+
+# フォールバック: GitHub API (未認証 60 req/時/IP のレート制限あり)
+if [ -z "$latest_tag" ]; then
+    if command -v curl >/dev/null 2>&1; then
+        api_response=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest")
+    else
+        api_response=$(wget -qO- "https://api.github.com/repos/$REPO/releases/latest")
+    fi
+    # jq なしで tag_name を抽出
+    latest_tag=$(echo "$api_response" | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/"tag_name"[[:space:]]*:[[:space:]]*"\(.*\)"/\1/')
+fi
 
 if [ -z "$latest_tag" ]; then
     echo "[ERROR] 最新バージョンの取得に失敗しました"

--- a/scripts/install/update-macos.sh
+++ b/scripts/install/update-macos.sh
@@ -29,13 +29,27 @@ echo ""
 echo "アーキテクチャ: $ARCH"
 
 # ── 最新バージョンを取得 ──
+# GitHub API (未認証 60 req/時/IP) はレート制限に当たりやすいため、
+# まず releases/latest への HTTP リダイレクト先 (Location ヘッダ) からタグを
+# 取得する経路を優先する (API 不要・レート制限なし)。失敗した場合のみ API に
+# フォールバックする。
 echo ""
 echo "最新バージョンを確認しています..."
 
-api_response=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest")
+latest_tag=""
 
-# jq なしで tag_name を抽出
-latest_tag=$(echo "$api_response" | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/"tag_name"[[:space:]]*:[[:space:]]*"\(.*\)"/\1/')
+redirect_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "https://github.com/$REPO/releases/latest" 2>/dev/null) || redirect_url=""
+
+case "$redirect_url" in
+    */releases/tag/v[0-9]*) latest_tag=$(echo "$redirect_url" | sed 's#.*/releases/tag/##') ;;
+esac
+
+# フォールバック: GitHub API (未認証 60 req/時/IP のレート制限あり)
+if [ -z "$latest_tag" ]; then
+    api_response=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest")
+    # jq なしで tag_name を抽出
+    latest_tag=$(echo "$api_response" | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/"tag_name"[[:space:]]*:[[:space:]]*"\(.*\)"/\1/')
+fi
 
 if [ -z "$latest_tag" ]; then
     echo "[ERROR] 最新バージョンの取得に失敗しました"

--- a/scripts/install/update.sh
+++ b/scripts/install/update.sh
@@ -15,19 +15,38 @@ echo "=== muhenkan-switch アップデーター (Linux) ==="
 echo ""
 
 # ── 最新バージョンを取得 ──
+# GitHub API (未認証 60 req/時/IP) はレート制限に当たりやすいため、
+# まず releases/latest への HTTP リダイレクト先 (Location ヘッダ) からタグを
+# 取得する経路を優先する (API 不要・レート制限なし)。失敗した場合のみ API に
+# フォールバックする。
 echo "最新バージョンを確認しています..."
 
+latest_tag=""
+
 if command -v curl &>/dev/null; then
-    api_response=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest")
+    redirect_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "https://github.com/$REPO/releases/latest" 2>/dev/null) || redirect_url=""
 elif command -v wget &>/dev/null; then
-    api_response=$(wget -qO- "https://api.github.com/repos/$REPO/releases/latest")
+    redirect_url=$(wget --max-redirect=20 --server-response --spider -q -O /dev/null "https://github.com/$REPO/releases/latest" 2>&1 \
+        | grep -i 'Location:' | tail -1 | tr -d '[:space:]') || redirect_url=""
 else
     echo "[ERROR] curl または wget が必要です"
     exit 1
 fi
 
-# jq なしで tag_name を抽出
-latest_tag=$(echo "$api_response" | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/"tag_name"[[:space:]]*:[[:space:]]*"\(.*\)"/\1/')
+case "$redirect_url" in
+    */releases/tag/v[0-9]*) latest_tag=$(echo "$redirect_url" | sed 's#.*/releases/tag/##') ;;
+esac
+
+# フォールバック: GitHub API (未認証 60 req/時/IP のレート制限あり)
+if [ -z "$latest_tag" ]; then
+    if command -v curl &>/dev/null; then
+        api_response=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest")
+    else
+        api_response=$(wget -qO- "https://api.github.com/repos/$REPO/releases/latest")
+    fi
+    # jq なしで tag_name を抽出
+    latest_tag=$(echo "$api_response" | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/"tag_name"[[:space:]]*:[[:space:]]*"\(.*\)"/\1/')
+fi
 
 if [ -z "$latest_tag" ]; then
     echo "[ERROR] 最新バージョンの取得に失敗しました"


### PR DESCRIPTION
## 概要

Closes #231

`get.sh` / `update.sh` / `update-macos.sh` / `get.ps1` が未認証の GitHub API
(`api.github.com/.../releases/latest`、60 req/時/IP のレート制限あり) を
最新バージョン取得の唯一の経路にしていたため、社内 NAT や共有回線でレート制限に
かかると「取得に失敗」となりフォールバックがなかった。

## 変更内容

- **get.sh / update.sh / update-macos.sh**: `https://github.com/<repo>/releases/latest`
  への HTTP リダイレクト先 (`Location` ヘッダ) からタグ名を取得する経路を主経路にした
  (API 不要・レート制限なし)。取得できなかった場合のみ従来の GitHub API 呼び出しに
  フォールバックする。ダウンロード URL 自体はアセット名が固定 (バージョン非依存) の
  ため元々レート制限の影響を受けておらず、変更していない。
- **get.ps1**: 同様に HTTP リダイレクトからタグを取得する経路を追加。Windows の
  インストーラー名はバージョン番号を含む (`muhenkan-switch_<version>_x64-setup.exe`)
  ため、NSIS の既定命名規則からアセット名を予測して
  `releases/latest/download/<asset>` からダウンロードする。予測したアセット名が
  存在しない場合は GitHub API でアセット一覧を取得し直して 1 度だけ再試行する。

## 検証結果

- `bash -n` / `sh -n` / `dash -n` で `get.sh` / `update.sh` / `update-macos.sh` の
  構文チェック: いずれも OK
- `get.ps1` は実行環境に `pwsh` が無かったため構文チェックは目視のみ (PowerShell
  5.1 / 7 双方で `HttpWebRequest.AllowAutoRedirect = $false` は WebException を
  投げず 3xx 応答をそのまま返す仕様を利用しており、両バージョンで動作する想定)
- 実際に `kimushun1101/muhenkan-switch` に対してリダイレクト方式のタグ取得ロジックを
  `curl` / `wget` の両方式で実行し、現行最新タグ `v0.11.4` が取得できることを確認
- `set -eu` 下でリダイレクト失敗時に API フォールバックへ正しく分岐することを
  ネットワークエラーを模した別スクリプトで確認
- 構築したダウンロード URL (Linux/macOS 3 アセット + Windows exe) が実際に
  HTTP 200 で解決することを `curl -I` で確認