### PR TITLE
refactor: パス解決・ps_processes・parent().unwrap() の重複整理 (#228)

### DIFF
--- a/muhenkan-switch-config/src/lib.rs
+++ b/muhenkan-switch-config/src/lib.rs
@@ -218,6 +218,43 @@ fn default_delimiter() -> String {
     "_".to_string()
 }
 
+// ── Shared alongside-exe path resolution ──
+
+/// 実行ファイルと同じディレクトリ、次に `manifest_dir/../bin/` の順で
+/// `name` という名前のファイルを探索し、見つかった完全パスを返す。
+///
+/// muhenkan-switch (kanata バイナリ / kbd ファイル / muhenkan-switch-core バイナリ) と
+/// muhenkan-switch-config (config.toml) に共通する「exe と同じディレクトリ →
+/// ワークスペースルートの bin/」という 2 段探索を集約したヘルパー。
+/// `manifest_dir` は呼び出し側クレートの `env!("CARGO_MANIFEST_DIR")` を渡す
+/// (`env!` はマクロ展開されるクレート側のパスになるため、呼び出し元でしか取得できない)。
+///
+/// 探索順序:
+/// 1. 実行ファイルと同じディレクトリ（インストール環境 / dev: ./bin/ 実行時）
+/// 2. `manifest_dir`/../bin/（開発環境: cargo run 互換）
+pub fn resolve_alongside_exe(name: &str, manifest_dir: &str) -> Option<PathBuf> {
+    // 1. 実行ファイルと同じディレクトリ
+    if let Ok(exe_path) = std::env::current_exe() {
+        if let Some(dir) = exe_path.parent() {
+            let path = dir.join(name);
+            if path.exists() {
+                return Some(path);
+            }
+        }
+    }
+
+    // 2. ワークスペースルートの bin/（開発環境）
+    let bin_dir = PathBuf::from(manifest_dir).parent().map(|p| p.join("bin"));
+    if let Some(dir) = bin_dir {
+        let path = dir.join(name);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    None
+}
+
 // ── Config path resolution ──
 
 /// config.toml のパスを決定する。
@@ -226,28 +263,7 @@ fn default_delimiter() -> String {
 /// 2. CARGO_MANIFEST_DIR/../bin/config.toml（開発環境: cargo run 互換）
 /// 3. 見つからなければ None（default_config() の embedded config で補完）
 pub fn config_path() -> Option<PathBuf> {
-    // 1. 実行ファイルと同じディレクトリ
-    if let Ok(exe_path) = std::env::current_exe() {
-        if let Some(dir) = exe_path.parent() {
-            let path = dir.join("config.toml");
-            if path.exists() {
-                return Some(path);
-            }
-        }
-    }
-
-    // 2. ワークスペースルートの bin/（開発環境）
-    let bin_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .map(|p| p.join("bin"));
-    if let Some(ref dir) = bin_dir {
-        let path = dir.join("config.toml");
-        if path.exists() {
-            return Some(path);
-        }
-    }
-
-    None
+    resolve_alongside_exe("config.toml", env!("CARGO_MANIFEST_DIR"))
 }
 
 /// 指定パスから config.toml を読み込む。
@@ -1114,5 +1130,50 @@ mod tests {
             command: Some("code".to_string()),
         };
         assert_eq!(entry2.command(), Some("code"));
+    }
+
+    /// `resolve_alongside_exe` がワークスペースルート `bin/` 配下のファイルを
+    /// 見つけられることを検証する（`manifest_dir/../bin/<name>` の探索順序）。
+    #[test]
+    fn test_resolve_alongside_exe_finds_file_in_manifest_bin_dir() {
+        let workspace_root = unique_temp_dir("found");
+        let bin_dir = workspace_root.join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let file_name = "resolve-test-target.txt";
+        let target = bin_dir.join(file_name);
+        std::fs::write(&target, b"test").unwrap();
+
+        // manifest_dir はワークスペースルート直下の架空クレートディレクトリを模す
+        let manifest_dir = workspace_root.join("some-crate");
+        let resolved = resolve_alongside_exe(file_name, manifest_dir.to_str().unwrap());
+        assert_eq!(resolved, Some(target));
+
+        let _ = std::fs::remove_dir_all(&workspace_root);
+    }
+
+    /// exe と同じディレクトリにも `manifest_dir/../bin/` にも見つからない場合は
+    /// `None` を返すことを検証する。
+    #[test]
+    fn test_resolve_alongside_exe_returns_none_when_not_found() {
+        let workspace_root = unique_temp_dir("missing");
+        // bin/ ディレクトリ自体を作らない = 見つからないケース
+        let manifest_dir = workspace_root.join("some-crate");
+
+        let resolved = resolve_alongside_exe("does-not-exist.bin", manifest_dir.to_str().unwrap());
+        assert_eq!(resolved, None);
+    }
+
+    /// テスト間で衝突しない一時ディレクトリパスを生成する（未作成。呼び出し側で mkdir する）。
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "muhenkan-switch-config-test-{}-{}-{}",
+            label,
+            std::process::id(),
+            nanos
+        ))
     }
 }

--- a/muhenkan-switch-core/src/commands/open_gui.rs
+++ b/muhenkan-switch-core/src/commands/open_gui.rs
@@ -27,7 +27,10 @@ fn gui_binary_path() -> Option<PathBuf> {
     let name = gui_binary_name();
 
     // 1. exe と同じディレクトリ
-    if let Ok(exe_dir) = std::env::current_exe().map(|p| p.parent().unwrap().to_path_buf()) {
+    if let Some(exe_dir) = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+    {
         let path = exe_dir.join(name);
         if path.exists() {
             return Some(path);

--- a/muhenkan-switch/src/commands.rs
+++ b/muhenkan-switch/src/commands.rs
@@ -251,44 +251,12 @@ mod imp {
     }
 }
 
-// ── Platform: Linux ──
+// ── Platform: Linux / macOS ──
+//
+// 両 OS とも `ps -eo pid,comm` の出力をパースするだけで、実装が完全に同一なため
+// 単一の `imp` モジュールに統合している (#228)。
 
-#[cfg(target_os = "linux")]
-mod imp {
-    use super::ProcessInfo;
-
-    pub(super) fn get_processes_impl() -> anyhow::Result<Vec<ProcessInfo>> {
-        ps_processes()
-    }
-
-    fn ps_processes() -> anyhow::Result<Vec<ProcessInfo>> {
-        let output = std::process::Command::new("ps")
-            .args(["-eo", "pid,comm"])
-            .output()?;
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let mut processes = Vec::new();
-        let mut seen = std::collections::HashSet::new();
-
-        for line in stdout.lines().skip(1) {
-            let parts: Vec<&str> = line.trim().splitn(2, char::is_whitespace).collect();
-            if parts.len() == 2 {
-                let pid: u32 = parts[0].trim().parse().unwrap_or(0);
-                let name = parts[1].trim().to_string();
-                if !seen.contains(&name) {
-                    seen.insert(name.clone());
-                    processes.push(ProcessInfo { name, pid });
-                }
-            }
-        }
-
-        processes.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
-        Ok(processes)
-    }
-}
-
-// ── Platform: macOS ──
-
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 mod imp {
     use super::ProcessInfo;
 

--- a/muhenkan-switch/src/kanata.rs
+++ b/muhenkan-switch/src/kanata.rs
@@ -172,94 +172,49 @@ impl KanataManager {
 
     /// kanata バイナリのパスを取得
     ///
-    /// 探索順序:
+    /// 探索順序 (共通ヘルパー `muhenkan_switch_config::resolve_alongside_exe` に集約):
     /// 1. exe と同じディレクトリ（インストール環境 / dev: ./bin/ 実行時）
     /// 2. CARGO_MANIFEST_DIR/../bin/（開発環境: cargo run 互換）
     fn kanata_path() -> Result<PathBuf> {
-        let name = kanata_binary_name();
-
-        // 1. exe と同じディレクトリ
-        if let Ok(exe_dir) = std::env::current_exe().map(|p| p.parent().unwrap().to_path_buf()) {
-            let path = exe_dir.join(name);
-            if path.exists() {
-                return Ok(path);
-            }
-        }
-
-        // 2. ワークスペースルートの bin/（開発環境）
-        let bin_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .map(|p| p.join("bin"));
-        if let Some(ref dir) = bin_dir {
-            let path = dir.join(name);
-            if path.exists() {
-                return Ok(path);
-            }
-        }
-
-        anyhow::bail!(
-            "キー割当の起動に必要なファイルが見つかりません。\n\
-             再インストールしてください。"
-        );
+        use muhenkan_switch_config::resolve_alongside_exe as resolve;
+        resolve(kanata_binary_name(), env!("CARGO_MANIFEST_DIR")).ok_or_else(|| {
+            anyhow::anyhow!(
+                "キー割当の起動に必要なファイルが見つかりません。\n\
+                 再インストールしてください。"
+            )
+        })
     }
 
     /// kanata 設定ファイルのパスを取得
     ///
-    /// 探索順序:
+    /// 探索順序 (共通ヘルパー `muhenkan_switch_config::resolve_alongside_exe` に集約):
     /// 1. exe と同じディレクトリの muhenkan.kbd（インストール環境 / dev: ./bin/ 実行時）
     /// 2. CARGO_MANIFEST_DIR/../bin/muhenkan.kbd（開発環境: cargo run 互換）
     fn kbd_path() -> Result<PathBuf> {
-        // 1. exe と同じディレクトリ
-        if let Ok(exe_dir) = std::env::current_exe().map(|p| p.parent().unwrap().to_path_buf()) {
-            let path = exe_dir.join("muhenkan.kbd");
-            if path.exists() {
-                return Ok(path);
-            }
-        }
-
-        // 2. ワークスペースルートの bin/（開発環境）
-        let bin_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .map(|p| p.join("bin"));
-        if let Some(ref dir) = bin_dir {
-            let path = dir.join("muhenkan.kbd");
-            if path.exists() {
-                return Ok(path);
-            }
-        }
-
-        anyhow::bail!(
-            "キー割当の設定ファイルが見つかりません。\n\
-             再インストールしてください。"
-        );
+        use muhenkan_switch_config::resolve_alongside_exe as resolve;
+        resolve("muhenkan.kbd", env!("CARGO_MANIFEST_DIR")).ok_or_else(|| {
+            anyhow::anyhow!(
+                "キー割当の設定ファイルが見つかりません。\n\
+                 再インストールしてください。"
+            )
+        })
     }
 
     /// muhenkan-switch-core バイナリが存在するディレクトリを取得
     ///
-    /// 探索順序:
+    /// 探索順序 (共通ヘルパー `muhenkan_switch_config::resolve_alongside_exe` に集約。
+    /// バイナリ自体のフルパスから親ディレクトリを取り出す):
     /// 1. exe と同じディレクトリ（インストール環境 / dev: ./bin/ 実行時）
     /// 2. CARGO_MANIFEST_DIR/../bin/（開発環境: cargo run 互換）
     fn core_binary_dir() -> Result<PathBuf> {
-        let name = core_binary_name();
-
-        // 1. exe と同じディレクトリ
-        if let Ok(exe_dir) = std::env::current_exe().map(|p| p.parent().unwrap().to_path_buf()) {
-            if exe_dir.join(name).exists() {
-                return Ok(exe_dir);
-            }
-        }
-
-        // 2. ワークスペースルートの bin/（開発環境）
-        let bin_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .map(|p| p.join("bin"));
-        if let Some(ref dir) = bin_dir {
-            if dir.join(name).exists() {
-                return Ok(dir.clone());
-            }
-        }
-
-        anyhow::bail!("キー割当の補助プログラムが見つかりません。\n再インストールしてください。");
+        use muhenkan_switch_config::resolve_alongside_exe as resolve;
+        resolve(core_binary_name(), env!("CARGO_MANIFEST_DIR"))
+            .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "キー割当の補助プログラムが見つかりません。\n再インストールしてください。"
+                )
+            })
     }
 
     /// kbd ファイルのパスを外部に公開する（句読点書き換え用）


### PR DESCRIPTION
## 概要

Issue #228 で指摘された 3 点の重複コードをリファクタリング。**挙動は変更していない**（探索順序・探索パス・エラーメッセージは全て維持）。

## 1. パス解決ロジックの共通化

### 依存関係の確認

- `muhenkan-switch` (GUI crate) は既に `muhenkan-switch-config` に依存
- `muhenkan-switch-core` も既に `muhenkan-switch-config` に依存

→ Cargo.toml の変更は不要。共通ヘルパーは `muhenkan-switch-config` (両 crate から参照可能) に配置。

### 追加した共通ヘルパー

`muhenkan-switch-config/src/lib.rs` に `pub fn resolve_alongside_exe(name: &str, manifest_dir: &str) -> Option<PathBuf>` を追加。

- `manifest_dir` を引数化しているのは、`env!("CARGO_MANIFEST_DIR")` がマクロ展開されるクレート側の値になり、呼び出し元でしか取得できないため（呼び出し側が自分の `env!("CARGO_MANIFEST_DIR")` を渡す）。
- 探索順序: 1. exe と同じディレクトリ → 2. `manifest_dir/../bin/`

### 各呼び出し箇所の突き合わせ結果

| 呼び出し箇所 | 旧探索順序 | 共通化 | 備考 |
|---|---|---|---|
| `kanata.rs::kanata_path` | exe dir → `CARGO_MANIFEST_DIR/../bin/` (2 段) | ✅ `resolve_alongside_exe` に置換 | 完全一致 |
| `kanata.rs::kbd_path` | 同上 (ファイル名固定 `muhenkan.kbd`) | ✅ 置換 | 完全一致 |
| `kanata.rs::core_binary_dir` | 同上、ただし戻り値は「バイナリの親ディレクトリ」 | ✅ 置換 + `.and_then(\|p\| p.parent().map(...))` でディレクトリを取り出す | 探索ロジックは完全一致。戻り値の形だけ異なるため関数側で吸収 |
| `muhenkan-switch-config/src/lib.rs::config_path` | 同上 (ファイル名 `config.toml`) | ✅ 置換 | 完全一致 |
| `muhenkan-switch-core/src/commands/open_gui.rs::gui_binary_path` | ① exe dir → ② **カレントディレクトリの bin/** → ③ ワークスペースルート bin/ → ④ **target/debug/** の 4 段 | **対象外**（詳細は下記） | ①③ は共通ヘルパーと同じロジックだが、間に②が割り込むため単純に共通ヘルパーを呼ぶと ②→③ の探索順序が変わってしまう（②を飛ばして先に③相当のロジックが走る形にはできない）。誤って順序を変えるリスクを避けるため独自実装のまま残し、`p.parent().unwrap()` の除去のみ実施 |

## 2. ps_processes の統合

`muhenkan-switch/src/commands.rs` の Linux 版・macOS 版 `mod imp`（`ps -eo pid,comm` をパースするだけの実装）はバイト単位で完全同一だったため、`#[cfg(any(target_os = "linux", target_os = "macos"))]` の単一モジュールに統合。

## 3. `p.parent().unwrap()` の除去

以下 4 箇所を `Option` チェーン（`.and_then(|p| p.parent().map(...))` または共通ヘルパー内部の `if let Some(dir) = ...` ）に置き換え、他の分岐と同じ「見つからなければ次の探索へ」という方針に統一：

- `kanata.rs` (`kanata_path` / `kbd_path` / `core_binary_dir`) — 共通ヘルパーへの置換で解消
- `muhenkan-switch-core/src/commands/open_gui.rs::gui_binary_path` — 個別に Option チェーンへ書き換え

## テスト

共通ヘルパー `resolve_alongside_exe` にユニットテストを追加（`muhenkan-switch-config/src/lib.rs`）:
- `test_resolve_alongside_exe_finds_file_in_manifest_bin_dir`
- `test_resolve_alongside_exe_returns_none_when_not_found`

## 検証結果

- `cd muhenkan-switch/frontend && npm ci && npm run build` → 成功
- `mise trust && mise run fetch-kanata` → 成功（GUI crate の build script が要求する externalBin を用意）
- `CARGO_TARGET_DIR=... cargo check --workspace` → 成功（warning なし）
- `CARGO_TARGET_DIR=... cargo test --workspace` → **85 件全て pass**（新規 2 件含む）
- `cargo clippy --workspace --all-targets` → warning 9 件（変更前と同数。新規 warning なし）
- 新規コード部分は `rustfmt --check` でも整形済み（プロジェクト全体は rustfmt 未適用の既存差分があるため、変更外ファイルは触っていない）

Closes #228