### PR TITLE
CI 強化: shellcheck / clippy・fmt / クロス OS cargo check / release キャッシュ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,16 +48,53 @@ jobs:
       - name: Build frontend (Vite)
         run: npm --prefix muhenkan-switch/frontend run build
 
+  shellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          scandir: './scripts'
+
+  psscriptanalyzer:
+    # PSScriptAnalyzer は pwsh があれば OS を問わず動くため、
+    # 追加セットアップ不要な ubuntu-latest (pwsh プリインストール済み) で実行する
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run PSScriptAnalyzer on get.ps1
+        shell: pwsh
+        run: |
+          Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser -Repository PSGallery
+          $results = Invoke-ScriptAnalyzer -Path scripts/install/get.ps1 -Severity Warning, Error
+          $results | Format-Table -AutoSize
+          if ($results.Count -gt 0) {
+            Write-Error "PSScriptAnalyzer found $($results.Count) issue(s) in get.ps1."
+            exit 1
+          }
+
   rust-check:
-    # Tauri GUI のクロス OS ビルドは重いので release.yml に委ね、CI では Linux のみ
+    # Tauri GUI のクロス OS ビルドは重いので release.yml に委ね、CI (Linux) では
+    # fmt/clippy/test を含むフルチェックを行う。Windows/macOS 向けの軽量
+    # cargo check は rust-check-cross-os で別途行う。
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
 
       - uses: Swatinem/rust-cache@v2
+
+      - name: cargo fmt --check
+        run: cargo fmt --all --check
 
       - uses: actions/setup-node@v6
         with:
@@ -101,8 +138,60 @@ jobs:
           touch muhenkan-switch/binaries/muhenkan-switch-core-x86_64-unknown-linux-gnu
           touch muhenkan-switch/binaries/kanata_cmd_allowed-x86_64-unknown-linux-gnu
 
+      - name: cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
       - name: cargo check
         run: cargo check --workspace
 
       - name: cargo test
         run: cargo test --workspace
+
+  rust-check-cross-os:
+    # target_os cfg 分岐 (Windows 18 箇所 / macOS 9 箇所) がタグ push (release.yml)
+    # までコンパイルされない問題への対応。fmt/clippy/test は rust-check (Linux)
+    # に委ね、ここでは各 OS 上での軽量な cargo check のみを行う。
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: 'npm'
+          cache-dependency-path: muhenkan-switch/frontend/package-lock.json
+
+      # tauri::generate_context! が frontendDist (./frontend/dist) の実在を要求するため、
+      # cargo check 前に frontend を build しておく
+      - name: Install frontend dependencies
+        run: npm --prefix muhenkan-switch/frontend ci
+
+      - name: Build frontend (Vite)
+        run: npm --prefix muhenkan-switch/frontend run build
+
+      # tauri-build がビルド時に externalBin の実在を確認するため、
+      # ホストのターゲットトリプルに合わせたダミー sidecar ファイルを用意する
+      # (CI では実バイナリ不要、空ファイルで十分)
+      - name: Prepare sidecar placeholders
+        shell: bash
+        run: |
+          target="$(rustc -vV | sed -n 's/^host: //p')"
+          ext=""
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            ext=".exe"
+          fi
+          mkdir -p muhenkan-switch/binaries
+          touch "muhenkan-switch/binaries/muhenkan-switch-core-${target}${ext}"
+          touch "muhenkan-switch/binaries/kanata_cmd_allowed-${target}${ext}"
+
+      - name: cargo check
+        run: cargo check --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,13 @@ jobs:
         shell: pwsh
         run: |
           Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser -Repository PSGallery
-          $results = Invoke-ScriptAnalyzer -Path scripts/install/get.ps1 -Severity Warning, Error
+          # PSAvoidUsingWriteHost: get.ps1 は対話的インストーラーであり、
+          #   色付きコンソール出力 (-ForegroundColor) が本来の目的のため除外。
+          # PSUseBOMForUnicodeEncodedFile: get.ps1 は `irm <url> | iex` で生コンテンツを
+          #   評価する配布形態が前提 (ファイル先頭コメント参照)。BOM を付与すると
+          #   デコード後の文字列先頭に U+FEFF が残り iex がパースに失敗する恐れがあるため除外。
+          $results = Invoke-ScriptAnalyzer -Path scripts/install/get.ps1 -Severity Warning, Error `
+            -ExcludeRule PSAvoidUsingWriteHost, PSUseBOMForUnicodeEncodedFile
           $results | Format-Table -AutoSize
           if ($results.Count -gt 0) {
             Write-Error "PSScriptAnalyzer found $($results.Count) issue(s) in get.ps1."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,10 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
@@ -137,6 +141,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: x86_64-pc-windows-msvc
 
       - uses: actions/setup-node@v6
         with:

--- a/muhenkan-switch-config/src/lib.rs
+++ b/muhenkan-switch-config/src/lib.rs
@@ -10,10 +10,7 @@ pub mod svg;
 
 /// kbd ファイルでディスパッチに割り当てられている物理キーの一覧。
 pub const DISPATCH_KEYS: &[&str] = &[
-    "1", "2", "3", "4", "5",
-    "q", "w", "e", "r", "t",
-    "a", "s", "d", "f", "g",
-    "b",
+    "1", "2", "3", "4", "5", "q", "w", "e", "r", "t", "a", "s", "d", "f", "g", "b",
 ];
 
 // ── Types ──
@@ -542,12 +539,13 @@ pub fn validate(config: &Config) -> Vec<String> {
 // ── kbd punctuation rewrite ──
 
 /// kbd ファイル内の句読点行を指定スタイルに書き換える。
-pub fn rewrite_kbd_punctuation(
-    kbd_path: &std::path::Path,
-    style: &PunctuationStyle,
-) -> Result<()> {
-    let content = std::fs::read_to_string(kbd_path)
-        .with_context(|| format!("kbd ファイルの読み込みに失敗しました: {}", kbd_path.display()))?;
+pub fn rewrite_kbd_punctuation(kbd_path: &std::path::Path, style: &PunctuationStyle) -> Result<()> {
+    let content = std::fs::read_to_string(kbd_path).with_context(|| {
+        format!(
+            "kbd ファイルの読み込みに失敗しました: {}",
+            kbd_path.display()
+        )
+    })?;
 
     let patterns = [
         "(unicode 、)  (unicode 。)",
@@ -567,8 +565,12 @@ pub fn rewrite_kbd_punctuation(
         new_content = new_content.replace(pat, new_fragment);
     }
 
-    std::fs::write(kbd_path, new_content)
-        .with_context(|| format!("kbd ファイルの書き込みに失敗しました: {}", kbd_path.display()))?;
+    std::fs::write(kbd_path, new_content).with_context(|| {
+        format!(
+            "kbd ファイルの書き込みに失敗しました: {}",
+            kbd_path.display()
+        )
+    })?;
 
     Ok(())
 }
@@ -580,10 +582,12 @@ pub fn get_search_url<'a>(
     search: &'a IndexMap<String, SearchEntry>,
     engine: &str,
 ) -> Result<&'a str> {
-    search
-        .get(engine)
-        .map(|e| e.url())
-        .ok_or_else(|| anyhow::anyhow!("検索エンジン '{}' が config.toml に定義されていません", engine))
+    search.get(engine).map(|e| e.url()).ok_or_else(|| {
+        anyhow::anyhow!(
+            "検索エンジン '{}' が config.toml に定義されていません",
+            engine
+        )
+    })
 }
 
 /// フォルダのパスを取得する。
@@ -690,7 +694,10 @@ mod tests {
             editor = {key = "a", process = "Code", command = "code"}
         "#;
         let config: Config = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.search["google"].url(), "https://www.google.com/search?q={query}");
+        assert_eq!(
+            config.search["google"].url(),
+            "https://www.google.com/search?q={query}"
+        );
         assert_eq!(config.search["google"].dispatch_key(), Some("g"));
         assert_eq!(config.folders["documents"].path(), "~/Documents");
         assert_eq!(config.folders["documents"].dispatch_key(), Some("1"));
@@ -758,7 +765,10 @@ mod tests {
         "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         assert!(config.search["google"].dispatch_key().is_none());
-        assert_eq!(config.search["google"].url(), "https://www.google.com/search?q={query}");
+        assert_eq!(
+            config.search["google"].url(),
+            "https://www.google.com/search?q={query}"
+        );
         assert!(config.folders["documents"].dispatch_key().is_none());
         assert!(config.apps["editor"].dispatch_key().is_none());
     }
@@ -885,7 +895,11 @@ mod tests {
             },
         );
         let errors = validate(&config);
-        assert!(errors.len() >= 3, "Expected at least 3 errors, got: {:?}", errors);
+        assert!(
+            errors.len() >= 3,
+            "Expected at least 3 errors, got: {:?}",
+            errors
+        );
     }
 
     #[test]
@@ -960,7 +974,10 @@ mod tests {
         let loaded = load_from(&path).unwrap();
 
         // Verify search
-        assert_eq!(loaded.search["google"].url(), "https://www.google.com/search?q={query}");
+        assert_eq!(
+            loaded.search["google"].url(),
+            "https://www.google.com/search?q={query}"
+        );
         assert_eq!(loaded.search["google"].dispatch_key(), Some("g"));
 
         // Verify folders
@@ -1086,7 +1103,11 @@ mod tests {
         for (literal, expected) in cases {
             let toml_str = format!("punctuation_style = \"{}\"\n", literal);
             let config: Config = toml::from_str(&toml_str).unwrap();
-            assert_eq!(config.punctuation_style, expected, "deserialize: {}", literal);
+            assert_eq!(
+                config.punctuation_style, expected,
+                "deserialize: {}",
+                literal
+            );
             let dumped = toml::to_string(&config).unwrap();
             assert!(
                 dumped.contains(&format!("punctuation_style = \"{}\"", literal)),
@@ -1109,7 +1130,10 @@ mod tests {
         // 4 variant 以外の文字列は deserialize 時点で reject される（型ガード）
         let toml_str = "punctuation_style = \"invalid\"\n";
         let result: Result<Config, _> = toml::from_str(toml_str);
-        assert!(result.is_err(), "invalid punctuation_style should fail to parse");
+        assert!(
+            result.is_err(),
+            "invalid punctuation_style should fail to parse"
+        );
     }
 
     #[test]

--- a/muhenkan-switch-config/src/svg.rs
+++ b/muhenkan-switch-config/src/svg.rs
@@ -84,10 +84,10 @@ fn qwerty_pos(row: usize, col: usize, hand_gap: f64) -> (f64, f64) {
     let pad = 20.0;
     // QWERTY 行スタガー（左端キーからの X オフセット）
     let row_offset = match row {
-        0 => 0.0,                // 数字行
-        1 => KEY_PITCH * 0.5,   // Q行（Tab 幅分）
-        2 => KEY_PITCH * 0.75,  // A行（CapsLock 幅分）
-        _ => KEY_PITCH * 1.25,  // Z行（Shift 幅分）
+        0 => 0.0,              // 数字行
+        1 => KEY_PITCH * 0.5,  // Q行（Tab 幅分）
+        2 => KEY_PITCH * 0.75, // A行（CapsLock 幅分）
+        _ => KEY_PITCH * 1.25, // Z行（Shift 幅分）
     };
     let x = pad + row_offset + col as f64 * KEY_PITCH + hand_gap;
     let y = pad + row as f64 * KEY_PITCH;
@@ -107,52 +107,292 @@ fn key_definitions() -> Vec<KeyDef> {
     vec![
         // ── 数字行 (row 0) ──
         //   1(c0) 2(c1) 3(c2) 4(c3) 5(c4)  6(c5) 7(c6) 8(c7) 9(c8) 0(c9)
-        KeyDef { label: "1", dispatch_key: Some("1"), x: l(0,0).0, y: l(0,0).1, category: KeyCategory::Dispatch },
-        KeyDef { label: "2", dispatch_key: Some("2"), x: l(0,1).0, y: l(0,1).1, category: KeyCategory::Dispatch },
-        KeyDef { label: "3", dispatch_key: Some("3"), x: l(0,2).0, y: l(0,2).1, category: KeyCategory::Dispatch },
-        KeyDef { label: "4", dispatch_key: Some("4"), x: l(0,3).0, y: l(0,3).1, category: KeyCategory::Dispatch },
-        KeyDef { label: "5", dispatch_key: Some("5"), x: l(0,4).0, y: l(0,4).1, category: KeyCategory::Dispatch },
-        KeyDef { label: "6", dispatch_key: None, x: r(0,5).0, y: r(0,5).1, category: KeyCategory::Unused },
-        KeyDef { label: "7", dispatch_key: None, x: r(0,6).0, y: r(0,6).1, category: KeyCategory::Unused },
-        KeyDef { label: "8", dispatch_key: None, x: r(0,7).0, y: r(0,7).1, category: KeyCategory::Unused },
-        KeyDef { label: "9", dispatch_key: None, x: r(0,8).0, y: r(0,8).1, category: KeyCategory::Unused },
-        KeyDef { label: "0", dispatch_key: None, x: r(0,9).0, y: r(0,9).1, category: KeyCategory::Unused },
+        KeyDef {
+            label: "1",
+            dispatch_key: Some("1"),
+            x: l(0, 0).0,
+            y: l(0, 0).1,
+            category: KeyCategory::Dispatch,
+        },
+        KeyDef {
+            label: "2",
+            dispatch_key: Some("2"),
+            x: l(0, 1).0,
+            y: l(0, 1).1,
+            category: KeyCategory::Dispatch,
+        },
+        KeyDef {
+            label: "3",
+            dispatch_key: Some("3"),
+            x: l(0, 2).0,
+            y: l(0, 2).1,
+            category: KeyCategory::Dispatch,
+        },
+        KeyDef {
+            label: "4",
+            dispatch_key: Some("4"),
+            x: l(0, 3).0,
+            y: l(0, 3).1,
+            category: KeyCategory::Dispatch,
+        },
+        KeyDef {
+            label: "5",
+            dispatch_key: Some("5"),
+            x: l(0, 4).0,
+            y: l(0, 4).1,
+            category: KeyCategory::Dispatch,
+        },
+        KeyDef {
+            label: "6",
+            dispatch_key: None,
+            x: r(0, 5).0,
+            y: r(0, 5).1,
+            category: KeyCategory::Unused,
+        },
+        KeyDef {
+            label: "7",
+            dispatch_key: None,
+            x: r(0, 6).0,
+            y: r(0, 6).1,
+            category: KeyCategory::Unused,
+        },
+        KeyDef {
+            label: "8",
+            dispatch_key: None,
+            x: r(0, 7).0,
+            y: r(0, 7).1,
+            category: KeyCategory::Unused,
+        },
+        KeyDef {
+            label: "9",
+            dispatch_key: None,
+            x: r(0, 8).0,
+            y: r(0, 8).1,
+            category: KeyCategory::Unused,
+        },
+        KeyDef {
+            label: "0",
+            dispatch_key: None,
+            x: r(0, 9).0,
+            y: r(0, 9).1,
+            category: KeyCategory::Unused,
+        },
         // ── Q行 (row 1) ──
         //   Q(c0) W(c1) E(c2) R(c3) T(c4)  |  Y(c5) U(c6) I(c7) O(c8) P(c9)
-        KeyDef { label: "Q", dispatch_key: Some("q"), x: l(1,0).0, y: l(1,0).1, category: KeyCategory::Dispatch },
-        KeyDef { label: "W", dispatch_key: Some("w"), x: l(1,1).0, y: l(1,1).1, category: KeyCategory::Dispatch },
-        KeyDef { label: "E", dispatch_key: Some("e"), x: l(1,2).0, y: l(1,2).1, category: KeyCategory::Dispatch },
-        KeyDef { label: "R", dispatch_key: Some("r"), x: l(1,3).0, y: l(1,3).1, category: KeyCategory::Dispatch },
-        KeyDef { label: "T", dispatch_key: Some("t"), x: l(1,4).0, y: l(1,4).1, category: KeyCategory::Dispatch },
-        KeyDef { label: "Y", dispatch_key: None, x: r(1,5).0, y: r(1,5).1, category: KeyCategory::TextEdit },
-        KeyDef { label: "U", dispatch_key: None, x: r(1,6).0, y: r(1,6).1, category: KeyCategory::TextEdit },
-        KeyDef { label: "I", dispatch_key: None, x: r(1,7).0, y: r(1,7).1, category: KeyCategory::TextEdit },
-        KeyDef { label: "O", dispatch_key: None, x: r(1,8).0, y: r(1,8).1, category: KeyCategory::TextEdit },
-        KeyDef { label: "P", dispatch_key: None, x: r(1,9).0, y: r(1,9).1, category: KeyCategory::Unused },
+        KeyDef {
+            label: "Q",
+            dispatch_key: Some("q"),
+            x: l(1, 0).0,
+            y: l(1, 0).1,
+            category: KeyCategory::Dispatch,
+        },
+        KeyDef {
+            label: "W",
+            dispatch_key: Some("w"),
+            x: l(1, 1).0,
+            y: l(1, 1).1,
+            category: KeyCategory::Dispatch,
+        },
+        KeyDef {
+            label: "E",
+            dispatch_key: Some("e"),
+            x: l(1, 2).0,
+            y: l(1, 2).1,
+            category: KeyCategory::Dispatch,
+        },
+        KeyDef {
+            label: "R",
+            dispatch_key: Some("r"),
+            x: l(1, 3).0,
+            y: l(1, 3).1,
+            category: KeyCategory::Dispatch,
+        },
+        KeyDef {
+            label: "T",
+            dispatch_key: Some("t"),
+            x: l(1, 4).0,
+            y: l(1, 4).1,
+            category: KeyCategory::Dispatch,
+        },
+        KeyDef {
+            label: "Y",
+            dispatch_key: None,
+            x: r(1, 5).0,
+            y: r(1, 5).1,
+            category: KeyCategory::TextEdit,
+        },
+        KeyDef {
+            label: "U",
+            dispatch_key: None,
+            x: r(1, 6).0,
+            y: r(1, 6).1,
+            category: KeyCategory::TextEdit,
+        },
+        KeyDef {
+            label: "I",
+            dispatch_key: None,
+            x: r(1, 7).0,
+            y: r(1, 7).1,
+            category: KeyCategory::TextEdit,
+        },
+        KeyDef {
+            label: "O",
+            dispatch_key: None,
+            x: r(1, 8).0,
+            y: r(1, 8).1,
+            category: KeyCategory::TextEdit,
+        },
+        KeyDef {
+            label: "P",
+            dispatch_key: None,
+            x: r(1, 9).0,
+            y: r(1, 9).1,
+            category: KeyCategory::Unused,
+        },
         // ── A行 / ホーム行 (row 2) ──
         //   A(c0) S(c1) D(c2) F(c3) G(c4)  |  H(c5) J(c6) K(c7) L(c8) ;(c9)
-        KeyDef { label: "A", dispatch_key: Some("a"), x: l(2,0).0, y: l(2,0).1, category: KeyCategory::Dispatch },
-        KeyDef { label: "S", dispatch_key: Some("s"), x: l(2,1).0, y: l(2,1).1, category: KeyCategory::Dispatch },
-        KeyDef { label: "D", dispatch_key: Some("d"), x: l(2,2).0, y: l(2,2).1, category: KeyCategory::Dispatch },
-        KeyDef { label: "F", dispatch_key: Some("f"), x: l(2,3).0, y: l(2,3).1, category: KeyCategory::Dispatch },
-        KeyDef { label: "G", dispatch_key: Some("g"), x: l(2,4).0, y: l(2,4).1, category: KeyCategory::Dispatch },
-        KeyDef { label: "H", dispatch_key: None, x: r(2,5).0, y: r(2,5).1, category: KeyCategory::TextEdit },
-        KeyDef { label: "J", dispatch_key: None, x: r(2,6).0, y: r(2,6).1, category: KeyCategory::TextEdit },
-        KeyDef { label: "K", dispatch_key: None, x: r(2,7).0, y: r(2,7).1, category: KeyCategory::TextEdit },
-        KeyDef { label: "L", dispatch_key: None, x: r(2,8).0, y: r(2,8).1, category: KeyCategory::TextEdit },
-        KeyDef { label: ";", dispatch_key: None, x: r(2,9).0, y: r(2,9).1, category: KeyCategory::TextEdit },
+        KeyDef {
+            label: "A",
+            dispatch_key: Some("a"),
+            x: l(2, 0).0,
+            y: l(2, 0).1,
+            category: KeyCategory::Dispatch,
+        },
+        KeyDef {
+            label: "S",
+            dispatch_key: Some("s"),
+            x: l(2, 1).0,
+            y: l(2, 1).1,
+            category: KeyCategory::Dispatch,
+        },
+        KeyDef {
+            label: "D",
+            dispatch_key: Some("d"),
+            x: l(2, 2).0,
+            y: l(2, 2).1,
+            category: KeyCategory::Dispatch,
+        },
+        KeyDef {
+            label: "F",
+            dispatch_key: Some("f"),
+            x: l(2, 3).0,
+            y: l(2, 3).1,
+            category: KeyCategory::Dispatch,
+        },
+        KeyDef {
+            label: "G",
+            dispatch_key: Some("g"),
+            x: l(2, 4).0,
+            y: l(2, 4).1,
+            category: KeyCategory::Dispatch,
+        },
+        KeyDef {
+            label: "H",
+            dispatch_key: None,
+            x: r(2, 5).0,
+            y: r(2, 5).1,
+            category: KeyCategory::TextEdit,
+        },
+        KeyDef {
+            label: "J",
+            dispatch_key: None,
+            x: r(2, 6).0,
+            y: r(2, 6).1,
+            category: KeyCategory::TextEdit,
+        },
+        KeyDef {
+            label: "K",
+            dispatch_key: None,
+            x: r(2, 7).0,
+            y: r(2, 7).1,
+            category: KeyCategory::TextEdit,
+        },
+        KeyDef {
+            label: "L",
+            dispatch_key: None,
+            x: r(2, 8).0,
+            y: r(2, 8).1,
+            category: KeyCategory::TextEdit,
+        },
+        KeyDef {
+            label: ";",
+            dispatch_key: None,
+            x: r(2, 9).0,
+            y: r(2, 9).1,
+            category: KeyCategory::TextEdit,
+        },
         // ── Z行 / 下行 (row 3) ──
         //   Z(c0) X(c1) C(c2) V(c3) B(c4)  |  N(c5) M(c6) ,(c7) .(c8) /(c9)
-        KeyDef { label: "Z", dispatch_key: None, x: l(3,0).0, y: l(3,0).1, category: KeyCategory::Timestamp },
-        KeyDef { label: "X", dispatch_key: None, x: l(3,1).0, y: l(3,1).1, category: KeyCategory::Timestamp },
-        KeyDef { label: "C", dispatch_key: None, x: l(3,2).0, y: l(3,2).1, category: KeyCategory::Timestamp },
-        KeyDef { label: "V", dispatch_key: None, x: l(3,3).0, y: l(3,3).1, category: KeyCategory::Timestamp },
-        KeyDef { label: "B", dispatch_key: Some("b"), x: l(3,4).0, y: l(3,4).1, category: KeyCategory::Dispatch },
-        KeyDef { label: "N", dispatch_key: None, x: r(3,5).0, y: r(3,5).1, category: KeyCategory::TextEdit },
-        KeyDef { label: "M", dispatch_key: None, x: r(3,6).0, y: r(3,6).1, category: KeyCategory::TextEdit },
-        KeyDef { label: ",", dispatch_key: None, x: r(3,7).0, y: r(3,7).1, category: KeyCategory::TextEdit },
-        KeyDef { label: ".", dispatch_key: None, x: r(3,8).0, y: r(3,8).1, category: KeyCategory::TextEdit },
-        KeyDef { label: "/", dispatch_key: None, x: r(3,9).0, y: r(3,9).1, category: KeyCategory::Unused },
+        KeyDef {
+            label: "Z",
+            dispatch_key: None,
+            x: l(3, 0).0,
+            y: l(3, 0).1,
+            category: KeyCategory::Timestamp,
+        },
+        KeyDef {
+            label: "X",
+            dispatch_key: None,
+            x: l(3, 1).0,
+            y: l(3, 1).1,
+            category: KeyCategory::Timestamp,
+        },
+        KeyDef {
+            label: "C",
+            dispatch_key: None,
+            x: l(3, 2).0,
+            y: l(3, 2).1,
+            category: KeyCategory::Timestamp,
+        },
+        KeyDef {
+            label: "V",
+            dispatch_key: None,
+            x: l(3, 3).0,
+            y: l(3, 3).1,
+            category: KeyCategory::Timestamp,
+        },
+        KeyDef {
+            label: "B",
+            dispatch_key: Some("b"),
+            x: l(3, 4).0,
+            y: l(3, 4).1,
+            category: KeyCategory::Dispatch,
+        },
+        KeyDef {
+            label: "N",
+            dispatch_key: None,
+            x: r(3, 5).0,
+            y: r(3, 5).1,
+            category: KeyCategory::TextEdit,
+        },
+        KeyDef {
+            label: "M",
+            dispatch_key: None,
+            x: r(3, 6).0,
+            y: r(3, 6).1,
+            category: KeyCategory::TextEdit,
+        },
+        KeyDef {
+            label: ",",
+            dispatch_key: None,
+            x: r(3, 7).0,
+            y: r(3, 7).1,
+            category: KeyCategory::TextEdit,
+        },
+        KeyDef {
+            label: ".",
+            dispatch_key: None,
+            x: r(3, 8).0,
+            y: r(3, 8).1,
+            category: KeyCategory::TextEdit,
+        },
+        KeyDef {
+            label: "/",
+            dispatch_key: None,
+            x: r(3, 9).0,
+            y: r(3, 9).1,
+            category: KeyCategory::Unused,
+        },
     ]
 }
 
@@ -218,15 +458,15 @@ pub fn generate(config: &Config) -> String {
 
     for key in &keys {
         let (fill, bottom_label) = match key.category {
-            KeyCategory::TextEdit => {
-                (fill_color("textedit"), text_edit_label(key.label, &config.punctuation_style).to_string())
-            }
-            KeyCategory::Timestamp => {
-                (fill_color("timestamp"), timestamp_label(key.label).to_string())
-            }
-            KeyCategory::Unused => {
-                (fill_color("unused"), String::new())
-            }
+            KeyCategory::TextEdit => (
+                fill_color("textedit"),
+                text_edit_label(key.label, &config.punctuation_style).to_string(),
+            ),
+            KeyCategory::Timestamp => (
+                fill_color("timestamp"),
+                timestamp_label(key.label).to_string(),
+            ),
+            KeyCategory::Unused => (fill_color("unused"), String::new()),
             KeyCategory::Dispatch => {
                 if let Some(dk) = key.dispatch_key {
                     if let Some((cat, name)) = lookup_dispatch(config, dk) {

--- a/muhenkan-switch-core/src/commands/keys.rs
+++ b/muhenkan-switch-core/src/commands/keys.rs
@@ -91,7 +91,12 @@ mod imp {
     /// Send Ctrl+<key> via Win32 SendInput.
     fn send_ctrl_key(vk: VIRTUAL_KEY) -> Result<()> {
         unsafe {
-            let mut inputs = [INPUT::default(), INPUT::default(), INPUT::default(), INPUT::default()];
+            let mut inputs = [
+                INPUT::default(),
+                INPUT::default(),
+                INPUT::default(),
+                INPUT::default(),
+            ];
 
             // Ctrl down
             inputs[0].r#type = INPUT_KEYBOARD;
@@ -125,7 +130,10 @@ mod imp {
 
             let sent = SendInput(&inputs, mem::size_of::<INPUT>() as i32);
             if sent != 4 {
-                anyhow::bail!("SendInput に失敗しました: 4 件中 {} 件のみ送信されました", sent);
+                anyhow::bail!(
+                    "SendInput に失敗しました: 4 件中 {} 件のみ送信されました",
+                    sent
+                );
             }
         }
         Ok(())

--- a/muhenkan-switch-core/src/commands/open_folder.rs
+++ b/muhenkan-switch-core/src/commands/open_folder.rs
@@ -7,7 +7,10 @@ pub fn run(target: &str, config: &Config) -> Result<()> {
     let path_str = config::get_folder_path(&config.folders, target)?;
 
     if path_str.is_empty() {
-        anyhow::bail!("フォルダ '{}' のパスが config.toml に設定されていません", target);
+        anyhow::bail!(
+            "フォルダ '{}' のパスが config.toml に設定されていません",
+            target
+        );
     }
 
     // ~ をホームディレクトリに展開
@@ -89,13 +92,16 @@ mod tests {
         };
         let result = run("nonexistent", &config);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("定義されていません"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("定義されていません"));
     }
 
     #[test]
     fn run_nonexistent_path_errors() {
-        use indexmap::IndexMap;
         use crate::config::FolderEntry;
+        use indexmap::IndexMap;
         let mut folders = IndexMap::new();
         folders.insert(
             "test".to_string(),
@@ -118,8 +124,8 @@ mod tests {
 
     #[test]
     fn run_empty_path_unknown_target_errors() {
-        use indexmap::IndexMap;
         use crate::config::FolderEntry;
+        use indexmap::IndexMap;
         let mut folders = IndexMap::new();
         folders.insert(
             "unknown".to_string(),
@@ -137,6 +143,9 @@ mod tests {
         };
         let result = run("unknown", &config);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("設定されていません"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("設定されていません"));
     }
 }

--- a/muhenkan-switch-core/src/commands/switch_app.rs
+++ b/muhenkan-switch-core/src/commands/switch_app.rs
@@ -6,10 +6,9 @@ use super::toast::Toast;
 use crate::config::Config;
 
 pub fn run(target: &str, config: &Config) -> Result<()> {
-    let entry = config
-        .apps
-        .get(target)
-        .ok_or_else(|| anyhow::anyhow!("アプリ '{}' が config.toml に定義されていません", target))?;
+    let entry = config.apps.get(target).ok_or_else(|| {
+        anyhow::anyhow!("アプリ '{}' が config.toml に定義されていません", target)
+    })?;
 
     let process_name = entry.process();
     let command = entry.command();
@@ -19,7 +18,10 @@ pub fn run(target: &str, config: &Config) -> Result<()> {
 
 /// プロセスが見つからず launch コマンドも未設定の場合に Toast で通知する。
 fn notify_process_not_found(app: &str) {
-    let msg = format!("'{}' が見つかりません — config.toml の command を設定してください", app);
+    let msg = format!(
+        "'{}' が見つかりません — config.toml の command を設定してください",
+        app
+    );
     Toast::notify(&msg);
 }
 
@@ -40,21 +42,20 @@ mod imp {
     use super::*;
     use std::ffi::OsString;
     use std::os::windows::ffi::OsStringExt;
+    use windows::core::BOOL;
+    use windows::Win32::Foundation::{HWND, LPARAM};
     use windows::Win32::System::Diagnostics::ToolHelp::{
         CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
         TH32CS_SNAPPROCESS,
     };
     use windows::Win32::System::Threading::{AttachThreadInput, GetCurrentThreadId};
     use windows::Win32::UI::Input::KeyboardAndMouse::{
-        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP,
-        VK_MENU,
+        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP, VK_MENU,
     };
     use windows::Win32::UI::WindowsAndMessaging::{
         EnumWindows, GetForegroundWindow, GetWindowThreadProcessId, IsIconic, IsWindowVisible,
         SetForegroundWindow, ShowWindow, SW_RESTORE,
     };
-    use windows::core::BOOL;
-    use windows::Win32::Foundation::{HWND, LPARAM};
 
     pub(super) fn activate_window(app: &str, launch: Option<&str>) -> Result<()> {
         // --- Step 1: Find PIDs matching the process name ---
@@ -117,10 +118,7 @@ mod imp {
             BOOL(1) // continue
         }
 
-        let mut data = CallbackData {
-            pids,
-            hwnd: None,
-        };
+        let mut data = CallbackData { pids, hwnd: None };
 
         unsafe {
             let _ = EnumWindows(
@@ -256,6 +254,7 @@ mod imp {
     /// 2. xdotool search --class (WM_CLASS でマッチ)
     /// 3. xdotool search --name (ウィンドウタイトルでマッチ)
     /// 4. pgrep + xdotool search --pid (バイナリ名から PID 経由でマッチ)
+    ///
     /// NOTE: Wayland でのアプリ切り替えは標準 API が未整備のため非対応 (#105)
     pub(super) fn activate_window(app: &str, launch: Option<&str>) -> Result<()> {
         let activated = try_wmctrl(app)
@@ -300,16 +299,12 @@ mod imp {
     /// pgrep でバイナリ名から PID を取得し、xdotool search --pid でウィンドウを前面化する。
     /// WM_CLASS がバイナリ名と異なるアプリ（例: zed-editor → dev.zed.Zed）に有効。
     pub(super) fn try_activate_by_pid(app: &str) -> bool {
-        let pgrep_output = Command::new("pgrep")
-            .args(["-x", app])
-            .output();
+        let pgrep_output = Command::new("pgrep").args(["-x", app]).output();
         let pids = match pgrep_output {
-            Ok(output) if output.status.success() => {
-                String::from_utf8_lossy(&output.stdout)
-                    .lines()
-                    .map(|s| s.to_string())
-                    .collect::<Vec<_>>()
-            }
+            Ok(output) if output.status.success() => String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>(),
             _ => return false,
         };
 
@@ -449,6 +444,9 @@ mod tests {
         };
         let result = run("nonexistent", &config);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("定義されていません"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("定義されていません"));
     }
 }

--- a/muhenkan-switch-core/src/commands/timestamp.rs
+++ b/muhenkan-switch-core/src/commands/timestamp.rs
@@ -174,12 +174,7 @@ fn explorer_rename_remove(
 }
 
 /// タイムスタンプを付加したファイルパスを構築
-fn build_timestamped_path(
-    src: &Path,
-    timestamp: &str,
-    position: &str,
-    delimiter: &str,
-) -> PathBuf {
+fn build_timestamped_path(src: &Path, timestamp: &str, position: &str, delimiter: &str) -> PathBuf {
     let stem = src.file_stem().unwrap_or_default().to_string_lossy();
     let ext = src
         .extension()
@@ -236,8 +231,8 @@ mod imp {
         };
         use windows::Win32::System::Variant::VARIANT;
         use windows::Win32::UI::Shell::{
-            IFolderView2, IShellItem, IShellItemArray, IShellWindows, ShellWindows,
-            SID_STopLevelBrowser, SIGDN_FILESYSPATH,
+            IFolderView2, IShellItem, IShellItemArray, IShellWindows, SID_STopLevelBrowser,
+            ShellWindows, SIGDN_FILESYSPATH,
         };
         use windows::Win32::UI::WindowsAndMessaging::{GetAncestor, GA_ROOT};
 

--- a/muhenkan-switch-core/src/commands/timestamp_settings.rs
+++ b/muhenkan-switch-core/src/commands/timestamp_settings.rs
@@ -6,8 +6,7 @@ use super::toast::Toast;
 /// Toast には現在の設定でファイル名がどう変化するかの例を表示する
 /// （GUI 設定画面のプレビューと同様の形式）。
 pub fn toggle_position() -> Result<()> {
-    let path = muhenkan_switch_config::config_path()
-        .context("config.toml が見つかりません")?;
+    let path = muhenkan_switch_config::config_path().context("config.toml が見つかりません")?;
 
     let mut config = muhenkan_switch_config::load_from(&path)?;
 

--- a/muhenkan-switch-core/src/commands/toast.rs
+++ b/muhenkan-switch-core/src/commands/toast.rs
@@ -13,9 +13,9 @@ mod imp {
     use windows::core::{w, PCWSTR};
     use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, RECT, WPARAM};
     use windows::Win32::Graphics::Gdi::{
-        BeginPaint, CreateSolidBrush, DeleteObject, DrawTextW, EndPaint, FillRect,
-        GetStockObject, InvalidateRect, SelectObject, SetBkMode, SetTextColor, DEFAULT_GUI_FONT,
-        DT_CENTER, DT_SINGLELINE, DT_VCENTER, PAINTSTRUCT, TRANSPARENT,
+        BeginPaint, CreateSolidBrush, DeleteObject, DrawTextW, EndPaint, FillRect, GetStockObject,
+        InvalidateRect, SelectObject, SetBkMode, SetTextColor, DEFAULT_GUI_FONT, DT_CENTER,
+        DT_SINGLELINE, DT_VCENTER, PAINTSTRUCT, TRANSPARENT,
     };
     use windows::Win32::System::LibraryLoader::GetModuleHandleW;
     use windows::Win32::UI::WindowsAndMessaging::*;
@@ -39,7 +39,10 @@ mod imp {
         /// Show the toast window immediately with an initial message.
         pub fn show(initial_message: &str) -> Self {
             let (tx, rx) = mpsc::channel::<String>();
-            let init_msg: Vec<u16> = initial_message.encode_utf16().chain(std::iter::once(0)).collect();
+            let init_msg: Vec<u16> = initial_message
+                .encode_utf16()
+                .chain(std::iter::once(0))
+                .collect();
 
             let handle = thread::spawn(move || {
                 run_toast_ui(rx, init_msg);
@@ -142,10 +145,8 @@ mod imp {
                     let ptr = GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut ToastData;
                     if !ptr.is_null() {
                         if let Ok(new_msg) = (*ptr).rx.try_recv() {
-                            (*ptr).message = new_msg
-                                .encode_utf16()
-                                .chain(std::iter::once(0))
-                                .collect();
+                            (*ptr).message =
+                                new_msg.encode_utf16().chain(std::iter::once(0)).collect();
                             let _ = InvalidateRect(Some(hwnd), None, true);
                             let _ = KillTimer(Some(hwnd), POLL_TIMER_ID);
                             let _ = SetTimer(Some(hwnd), DISMISS_TIMER_ID, 1500, None);
@@ -179,7 +180,10 @@ mod imp {
                 if !ptr.is_null() {
                     let msg_slice = &(*ptr).message;
                     // Find null terminator for text length
-                    let text_len = msg_slice.iter().position(|&c| c == 0).unwrap_or(msg_slice.len());
+                    let text_len = msg_slice
+                        .iter()
+                        .position(|&c| c == 0)
+                        .unwrap_or(msg_slice.len());
                     let text = PCWSTR::from_raw(msg_slice.as_ptr());
                     let _ = DrawTextW(
                         hdc,

--- a/muhenkan-switch-core/src/main.rs
+++ b/muhenkan-switch-core/src/main.rs
@@ -108,8 +108,8 @@ fn run() -> Result<()> {
         Commands::OpenFolder { target } => commands::open_folder::run(&target, &config),
         Commands::Timestamp { action } => commands::timestamp::run(&action, &config),
         Commands::Dispatch { key } => commands::dispatch::run(&key, &config),
-        Commands::OpenGui
-        | Commands::GenerateSvg { .. }
-        | Commands::ToggleTimestampPosition => unreachable!(),
+        Commands::OpenGui | Commands::GenerateSvg { .. } | Commands::ToggleTimestampPosition => {
+            unreachable!()
+        }
     }
 }

--- a/muhenkan-switch/src/commands.rs
+++ b/muhenkan-switch/src/commands.rs
@@ -35,7 +35,10 @@ pub fn generate_keyboard_svg() -> Result<String, String> {
 /// に対する既存の温度感 (警告して続行) に合わせて無視するが、kanata の起動 (start) の
 /// 失敗はキー割当が止まったままユーザーに伝わらなくなるため、握り潰さず呼び出し元に
 /// エラーとして伝搬する。
-fn rewrite_punctuation_and_restart_kanata(config: &Config, manager: &KanataManager) -> Result<(), String> {
+fn rewrite_punctuation_and_restart_kanata(
+    config: &Config,
+    manager: &KanataManager,
+) -> Result<(), String> {
     if let Ok(kbd_path) = KanataManager::resolve_kbd_path() {
         if let Err(e) = config::rewrite_kbd_punctuation(&kbd_path, &config.punctuation_style) {
             eprintln!("[config] kbd ファイルの句読点書き換えに失敗しました: {e:#}");
@@ -48,7 +51,11 @@ fn rewrite_punctuation_and_restart_kanata(config: &Config, manager: &KanataManag
 }
 
 #[tauri::command]
-pub fn save_config(app: tauri::AppHandle, config: Config, manager: State<KanataManager>) -> Result<(), String> {
+pub fn save_config(
+    app: tauri::AppHandle,
+    config: Config,
+    manager: State<KanataManager>,
+) -> Result<(), String> {
     use tauri::Emitter;
     let errors = config::validate(&config);
     if !errors.is_empty() {
@@ -85,13 +92,17 @@ pub async fn export_config(app: tauri::AppHandle) -> Result<bool, String> {
     let default_dir = dirs::desktop_dir()
         .or_else(dirs::download_dir)
         .or_else(dirs::home_dir);
-    let mut builder = app.dialog().file().add_filter("TOML", &["toml"]).set_file_name("muhenkan-switch-config.toml");
+    let mut builder = app
+        .dialog()
+        .file()
+        .add_filter("TOML", &["toml"])
+        .set_file_name("muhenkan-switch-config.toml");
     if let Some(dir) = default_dir {
         builder = builder.set_directory(dir);
     }
     builder.save_file(move |path| {
-            let _ = tx.send(path.map(|p| p.as_path().unwrap().to_path_buf()));
-        });
+        let _ = tx.send(path.map(|p| p.as_path().unwrap().to_path_buf()));
+    });
     let dest = rx.recv().map_err(|e| e.to_string())?;
     match dest {
         Some(dest) => {
@@ -103,7 +114,10 @@ pub async fn export_config(app: tauri::AppHandle) -> Result<bool, String> {
 }
 
 #[tauri::command]
-pub async fn import_config(app: tauri::AppHandle, manager: State<'_, KanataManager>) -> Result<Option<Config>, String> {
+pub async fn import_config(
+    app: tauri::AppHandle,
+    manager: State<'_, KanataManager>,
+) -> Result<Option<Config>, String> {
     use tauri_plugin_dialog::DialogExt;
     let (tx, rx) = std::sync::mpsc::channel();
     app.dialog()
@@ -138,14 +152,16 @@ pub async fn import_config(app: tauri::AppHandle, manager: State<'_, KanataManag
 #[tauri::command]
 pub fn get_app_presets() -> Result<serde_json::Value, String> {
     const PRESETS_JSON: &str = include_str!("../../config/app-presets.json");
-    let all: serde_json::Value =
-        serde_json::from_str(PRESETS_JSON).map_err(|e| e.to_string())?;
+    let all: serde_json::Value = serde_json::from_str(PRESETS_JSON).map_err(|e| e.to_string())?;
     let os_key = match std::env::consts::OS {
         "windows" => "windows",
         "macos" => "macos",
         _ => "linux",
     };
-    Ok(all.get(os_key).cloned().unwrap_or(serde_json::Value::Object(Default::default())))
+    Ok(all
+        .get(os_key)
+        .cloned()
+        .unwrap_or(serde_json::Value::Object(Default::default())))
 }
 
 // ── Search presets ──
@@ -212,8 +228,9 @@ mod imp {
         let mut seen = HashSet::new();
 
         unsafe {
-            let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
-                .map_err(|e| anyhow::anyhow!("プロセス一覧のスナップショット取得に失敗しました: {}", e))?;
+            let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0).map_err(|e| {
+                anyhow::anyhow!("プロセス一覧のスナップショット取得に失敗しました: {}", e)
+            })?;
             let mut entry = PROCESSENTRY32W {
                 dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
                 ..Default::default()
@@ -246,7 +263,7 @@ mod imp {
             let _ = windows::Win32::Foundation::CloseHandle(snapshot);
         }
 
-        processes.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        processes.sort_by_key(|a| a.name.to_lowercase());
         Ok(processes)
     }
 }
@@ -284,7 +301,7 @@ mod imp {
             }
         }
 
-        processes.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        processes.sort_by_key(|a| a.name.to_lowercase());
         Ok(processes)
     }
 }
@@ -337,7 +354,12 @@ pub async fn install_update(app: tauri::AppHandle) -> Result<(), String> {
             .map_err(|e| format!("{:#}", e))
     })
     .await
-    .unwrap_or_else(|e| Err(format!("アップデートインストール中にエラーが発生しました: {}", e)))
+    .unwrap_or_else(|e| {
+        Err(format!(
+            "アップデートインストール中にエラーが発生しました: {}",
+            e
+        ))
+    })
 }
 
 // ── Autostart ──
@@ -345,9 +367,7 @@ pub async fn install_update(app: tauri::AppHandle) -> Result<(), String> {
 #[tauri::command]
 pub fn get_autostart_enabled(app: tauri::AppHandle) -> Result<bool, String> {
     use tauri_plugin_autostart::ManagerExt;
-    app.autolaunch()
-        .is_enabled()
-        .map_err(|e| e.to_string())
+    app.autolaunch().is_enabled().map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -389,13 +409,11 @@ pub fn spawn_update_terminal() -> Result<(), String> {
 
     #[cfg(target_os = "linux")]
     {
-        let home = dirs::home_dir().ok_or_else(|| "ホームディレクトリが見つかりません".to_string())?;
+        let home =
+            dirs::home_dir().ok_or_else(|| "ホームディレクトリが見つかりません".to_string())?;
         let script = home.join(".local/share/muhenkan-switch/update.sh");
         if !script.exists() {
-            return Err(format!(
-                "update.sh が見つかりません: {}",
-                script.display()
-            ));
+            return Err(format!("update.sh が見つかりません: {}", script.display()));
         }
         // GUI 自身が nohup 等で stdin=/dev/null で起動されていると、spawn された
         // ターミナル内 bash の stdin も /dev/null を継承し、末尾の `read` が即 EOF
@@ -431,7 +449,8 @@ pub fn spawn_update_terminal() -> Result<(), String> {
 
     #[cfg(target_os = "macos")]
     {
-        let home = dirs::home_dir().ok_or_else(|| "ホームディレクトリが見つかりません".to_string())?;
+        let home =
+            dirs::home_dir().ok_or_else(|| "ホームディレクトリが見つかりません".to_string())?;
         let script = home.join("Library/Application Support/muhenkan-switch/update-macos.sh");
         if !script.exists() {
             return Err(format!(
@@ -463,8 +482,7 @@ pub async fn browse_folder(app: tauri::AppHandle) -> Result<Option<String>, Stri
     app.dialog().file().pick_folder(move |path| {
         let _ = tx.send(path.map(|p| p.to_string()));
     });
-    rx.recv()
-        .map_err(|e| e.to_string())
+    rx.recv().map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -598,7 +616,9 @@ document.addEventListener("keydown", e => {{
         {
             // HTML を直接評価して表示
             let escaped = escape_for_js_template_literal(&html);
-            let _ = win.eval(&format!("document.open();document.write(`{escaped}`);document.close();"));
+            let _ = win.eval(format!(
+                "document.open();document.write(`{escaped}`);document.close();"
+            ));
         }
     });
     Ok(())

--- a/muhenkan-switch/src/kanata.rs
+++ b/muhenkan-switch/src/kanata.rs
@@ -49,8 +49,7 @@ mod job_object {
 
         pub fn assign(&self, pid: u32) {
             unsafe {
-                if let Ok(process) =
-                    OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, false, pid)
+                if let Ok(process) = OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, false, pid)
                 {
                     let _ = AssignProcessToJobObject(self.0, process);
                     let _ = CloseHandle(process);
@@ -113,11 +112,7 @@ udevadm control --reload-rules && udevadm trigger
     /// uinput パーミッション未設定の案内を stderr に表示
     pub fn print_uinput_guide() {
         use std::fs::OpenOptions;
-        if OpenOptions::new()
-            .write(true)
-            .open("/dev/uinput")
-            .is_ok()
-        {
+        if OpenOptions::new().write(true).open("/dev/uinput").is_ok() {
             return;
         }
         eprintln!();
@@ -266,8 +261,9 @@ impl KanataManager {
             }
         }
 
-        let child = SharedChild::spawn(&mut cmd)
-            .with_context(|| "キー割当の起動に失敗しました。\n再インストールしてください。".to_string())?;
+        let child = SharedChild::spawn(&mut cmd).with_context(|| {
+            "キー割当の起動に失敗しました。\n再インストールしてください。".to_string()
+        })?;
 
         let pid = child.id();
         eprintln!("[kanata] started (pid: {})", pid);
@@ -316,44 +312,6 @@ impl KanataManager {
             }
             None => (false, None),
         }
-    }
-}
-
-// ── Tests ──
-//
-// start() は実際の kanata バイナリ（bin/kanata_cmd_allowed）が無いと
-// 起動に失敗するため、ここでは start() を伴わずに検証できる
-// intentional_stop フラグの初期値・stop() による更新のみをテストする。
-// start() 成功時のフラグリセット（本 Issue の修正本体）を含む
-// stop → start の完全な状態遷移テストは、実バイナリの用意または
-// プロセス起動を差し替える依存性注入が必要になり invasive なため見送る
-// （テスト整備は Issue #230 で扱う）。
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn new_intentional_stop_flag_initial_false() {
-        let manager = KanataManager::new();
-        assert!(!manager.intentional_stop_flag().load(Ordering::SeqCst));
-    }
-
-    #[test]
-    fn stop_without_running_child_sets_intentional_stop_flag() {
-        let manager = KanataManager::new();
-        let flag = manager.intentional_stop_flag();
-        assert!(!flag.load(Ordering::SeqCst));
-
-        let result = manager.stop();
-
-        assert!(result.is_ok());
-        assert!(flag.load(Ordering::SeqCst));
-    }
-
-    #[test]
-    fn status_with_no_child_returns_not_running() {
-        let manager = KanataManager::new();
-        assert_eq!(manager.status(), (false, None));
     }
 }
 
@@ -510,4 +468,42 @@ pub fn setup(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     });
 
     Ok(())
+}
+
+// ── Tests ──
+//
+// start() は実際の kanata バイナリ（bin/kanata_cmd_allowed）が無いと
+// 起動に失敗するため、ここでは start() を伴わずに検証できる
+// intentional_stop フラグの初期値・stop() による更新のみをテストする。
+// start() 成功時のフラグリセット（本 Issue の修正本体）を含む
+// stop → start の完全な状態遷移テストは、実バイナリの用意または
+// プロセス起動を差し替える依存性注入が必要になり invasive なため見送る
+// （テスト整備は Issue #230 で扱う）。
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_intentional_stop_flag_initial_false() {
+        let manager = KanataManager::new();
+        assert!(!manager.intentional_stop_flag().load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn stop_without_running_child_sets_intentional_stop_flag() {
+        let manager = KanataManager::new();
+        let flag = manager.intentional_stop_flag();
+        assert!(!flag.load(Ordering::SeqCst));
+
+        let result = manager.stop();
+
+        assert!(result.is_ok());
+        assert!(flag.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn status_with_no_child_returns_not_running() {
+        let manager = KanataManager::new();
+        assert_eq!(manager.status(), (false, None));
+    }
 }

--- a/muhenkan-switch/src/main.rs
+++ b/muhenkan-switch/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
-            Some(vec!["--hidden".into()]),
+            Some(vec!["--hidden"]),
         ))
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_updater::Builder::new().build())

--- a/muhenkan-switch/src/tray.rs
+++ b/muhenkan-switch/src/tray.rs
@@ -48,8 +48,8 @@ fn build_tray(handle: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         .checked(autostart_enabled)
         .build(handle)?;
     handle.manage(AutostartMenuHandle(autostart_item.clone()));
-    let open_dir_item = MenuItemBuilder::with_id("open_dir", "インストール先を開く")
-        .build(handle)?;
+    let open_dir_item =
+        MenuItemBuilder::with_id("open_dir", "インストール先を開く").build(handle)?;
     // インストーラー版 / スクリプト版どちらでも表示する。
     // listener 側 (initUpdater) で install type ごとに振り分け:
     //   - installer (Windows): tauri-plugin-updater 経由

--- a/scripts/install/get.ps1
+++ b/scripts/install/get.ps1
@@ -132,7 +132,13 @@ Write-Host "インストールしています..." -ForegroundColor Cyan
 # 起動中のインスタンスがあるとファイル上書きに失敗するため停止（更新時）。
 # Windows では Job Object により kanata も併せて終了する。
 Get-Process muhenkan-switch -ErrorAction SilentlyContinue | ForEach-Object {
-    try { $_.Kill(); [void]$_.WaitForExit(5000) } catch {}
+    try {
+        $_.Kill()
+        [void]$_.WaitForExit(5000)
+    } catch {
+        # 既に終了している等で Kill が失敗しても、以降のインストール処理は続行する
+        Write-Verbose "既存プロセスの終了に失敗しました: $_"
+    }
 }
 
 # /S = サイレントインストール。

--- a/scripts/install/update-macos.sh
+++ b/scripts/install/update-macos.sh
@@ -41,7 +41,7 @@ latest_tag=""
 redirect_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "https://github.com/$REPO/releases/latest" 2>/dev/null) || redirect_url=""
 
 case "$redirect_url" in
-    */releases/tag/v[0-9]*) latest_tag=$(echo "$redirect_url" | sed 's#.*/releases/tag/##') ;;
+    */releases/tag/v[0-9]*) latest_tag="${redirect_url##*/releases/tag/}" ;;
 esac
 
 # フォールバック: GitHub API (未認証 60 req/時/IP のレート制限あり)
@@ -63,7 +63,7 @@ if command -v muhenkan-switch-core &>/dev/null; then
     version_output=$(muhenkan-switch-core --version 2>/dev/null || true)
     if [ -n "$version_output" ]; then
         # "muhenkan-switch-core x.y.z" → "vx.y.z"
-        version_string=$(echo "$version_output" | sed 's/^muhenkan-switch-core *//')
+        read -r _ version_string <<< "$version_output"
         current_version="v$version_string"
     fi
 fi

--- a/scripts/install/update.sh
+++ b/scripts/install/update.sh
@@ -34,7 +34,7 @@ else
 fi
 
 case "$redirect_url" in
-    */releases/tag/v[0-9]*) latest_tag=$(echo "$redirect_url" | sed 's#.*/releases/tag/##') ;;
+    */releases/tag/v[0-9]*) latest_tag="${redirect_url##*/releases/tag/}" ;;
 esac
 
 # フォールバック: GitHub API (未認証 60 req/時/IP のレート制限あり)
@@ -60,7 +60,7 @@ if command -v muhenkan-switch-core &>/dev/null; then
     version_output=$(muhenkan-switch-core --version 2>/dev/null || true)
     if [ -n "$version_output" ]; then
         # "muhenkan-switch-core x.y.z" → "vx.y.z"
-        version_string=$(echo "$version_output" | sed 's/^muhenkan-switch-core[[:space:]]*//')
+        read -r _ version_string <<< "$version_output"
         current_version="v$version_string"
     fi
 fi


### PR DESCRIPTION
## 概要

Closes #226

CI で手薄だったシェルスクリプト・Rust のチェックを強化する。

## 実施内容

### a. shellcheck
- `scripts/**/*.sh` (16 ファイル) に対する shellcheck job を追加 (`ludeeus/action-shellcheck@2.0.0`, `scandir: ./scripts`)
- CI に追加する前にローカルで全スクリプトを検証し、指摘 (`scripts/install/update.sh` / `update-macos.sh` の `SC2001`: `echo | sed` を bash 組み込みのパラメータ展開・`read` に置換) を修正済み。挙動は変えていない (ローカルで置換前後の出力一致を確認)
- 除外設定 (`.shellcheckrc` 等) は不要 (全 severity で 0 件)

### b. PSScriptAnalyzer
- `scripts/install/get.ps1` 用の job を追加 (`ubuntu-latest` + `Invoke-ScriptAnalyzer`, `-Severity Warning, Error`)
- ローカルに `pwsh` が無いため未検証のまま追加 → PR CI で 32 件の指摘 (`PSAvoidUsingEmptyCatchBlock` 1 件 / `PSAvoidUsingWriteHost` 30 件 / `PSUseBOMForUnicodeEncodedFile` 1 件) が判明し、追加コミットで対応:
  - `PSAvoidUsingEmptyCatchBlock`: 空 catch ブロックに `Write-Verbose` でのログ出力を追加 (実際のコード品質修正)
  - `PSAvoidUsingWriteHost`: get.ps1 は対話的インストーラーで色付きコンソール出力が本来の目的のため `-ExcludeRule` で除外
  - `PSUseBOMForUnicodeEncodedFile`: get.ps1 は `irm <url> | iex` で生コンテンツを評価する配布形態が前提。BOM を付与するとデコード後の文字列先頭に U+FEFF が残り `iex` のパースに失敗する恐れがあるため除外
  - 除外理由は workflow 内にコメントで明記

### c. cargo fmt / clippy
- `rust-check` job に `cargo fmt --all --check` と `cargo clippy --workspace --all-targets -- -D warnings` を追加
- CI に追加する前にローカルで実施:
  - `cargo fmt --all` で既存の未整形差分 (15 ファイル、フォーマットのみ・ロジック変更なし) を解消
  - `cargo clippy --workspace --all-targets` の既存警告 9 件を修正 (すべて挙動を変えない最小修正):
    - `doc_lazy_continuation` (switch_app.rs): doc コメントの NOTE 行を独立した段落に
    - `unnecessary_sort_by` (commands.rs, 2 箇所): `sort_by` → `sort_by_key`
    - `needless_borrows_for_generic_args` (commands.rs): `win.eval(&format!(...))` → `win.eval(format!(...))`
    - `useless_conversion` (main.rs): `"--hidden".into()` → `"--hidden"` (対象型が既に `&str`)
    - `items_after_test_module` (kanata.rs): `mod tests` をファイル末尾に移動

### d. Windows/macOS cargo check
- `rust-check-cross-os` job (windows-latest / macos-latest matrix) を新設し、各 OS 上で `cargo check --workspace` を実行
- `target_os = "windows"` (18 箇所) / `"macos"` (9 箇所) の cfg 分岐が、タグ push (release.yml) までコンパイルされていなかった問題に対応
- fmt/clippy/test は Linux 側 (`rust-check`) に委ね、cross-os 側は軽量な check のみ
- sidecar プレースホルダーは `rustc -vV` からホストのターゲットトリプルを動的に取得して生成 (OS 決め打ちを避ける)

### e. release.yml へのキャッシュ追加
- `build` (ubuntu/macos x64・arm64 matrix) と `build-windows-nsis` の両ジョブに `Swatinem/rust-cache@v2` を追加
- 同一 OS で複数 target をビルドする `macos-latest` の matrix があるため、`key: ${{ matrix.target }}` でキャッシュを target 単位に分離

## ローカル検証結果

- `shellcheck` (v0.11.0, GitHub Releases から /tmp にダウンロードして使用): 全 16 スクリプト pass
- `cargo fmt --all --check`: pass
- `cargo clippy --workspace --all-targets -- -D warnings`: pass (警告 0 件)
- `cargo test --workspace`: 85 件 pass (config 43 / core 34 / gui 8)
- workflow yaml: `python3 -c "import yaml; yaml.safe_load(...)"` で構文チェック済み

## CI 結果

PR CI 2 往復 (初回: psscriptanalyzer が 32 件の指摘で fail → 修正 push → 全 green) で収束。全 8 job green:

- frontend-check (ubuntu/windows/macos) ✅
- shellcheck ✅
- psscriptanalyzer ✅
- rust-check (fmt + clippy + check + test) ✅
- rust-check-cross-os (windows/macos) ✅

## Test plan

- [x] ローカル shellcheck 全 pass
- [x] ローカル `cargo fmt --all --check` pass
- [x] ローカル `cargo clippy --workspace --all-targets -- -D warnings` pass
- [x] ローカル `cargo test --workspace` pass
- [x] workflow yaml 構文チェック
- [x] PR CI で shellcheck / PSScriptAnalyzer / rust-check (fmt+clippy) / rust-check-cross-os (windows/macos) / frontend-check が green