### PR TITLE
test: collect*/dom-utils/state と GUI 純粋ロジックのテストを拡充

### DIFF
--- a/muhenkan-switch/frontend/src/forms/__tests__/apps.test.ts
+++ b/muhenkan-switch/frontend/src/forms/__tests__/apps.test.ts
@@ -1,0 +1,511 @@
+// apps.ts のテスト。collectTimestamp / collectSearch / collectFolders のテストと
+// 同型の DOM 組み立てパターンに加え、createAppSelect / renderAppsList / addAppRow /
+// showProcessPicker / initAppsForm も含めて coverage.include の per-file 80% 閾値を
+// 満たす。
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  addAppRow,
+  collectApps,
+  createAppSelect,
+  initAppsForm,
+  renderAppsList,
+  showProcessPicker,
+} from '../apps';
+import { invoke } from '../../lib/tauri';
+import { resetConfig, setAppPresets, setConfig } from '../../lib/state';
+import type { CollectedConfig } from '../../lib/config-io';
+import type { Config, TimestampConfig } from '../../lib/config';
+import type { AppPresetMap } from '../../lib/state';
+
+vi.mock('../../lib/tauri', () => ({
+  invoke: vi.fn(),
+}));
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function emptyCollected(): CollectedConfig {
+  return {
+    search: {},
+    folders: {},
+    apps: {},
+    timestamp: {} as TimestampConfig,
+    punctuation_style: '、。',
+  };
+}
+
+function addRow(
+  container: HTMLElement,
+  name: string,
+  process: string,
+  command: string,
+  dispatchKey = '',
+  label = '',
+): void {
+  const row = document.createElement('div');
+  row.className = 'list-row';
+  row.innerHTML = `
+    <select class="dispatch-key-select"><option value="${dispatchKey}" selected>${dispatchKey}</option></select>
+    <input type="text" class="key-input" value="${name}">
+    <select class="app-select">
+      <option value="${process}" data-command="${command}">${label || process}</option>
+    </select>
+  `;
+  container.appendChild(row);
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('collectApps', () => {
+  it('collects a row with name, process, command and dispatch key', () => {
+    const container = document.createElement('div');
+    container.id = 'apps-list';
+    addRow(container, 'ブラウザ', 'chrome.exe', 'chrome', 'a', 'Chrome');
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectApps(collected);
+
+    expect(collected.apps['ブラウザ']).toEqual({
+      process: 'chrome.exe',
+      key: 'a',
+      command: 'chrome',
+    });
+  });
+
+  it('omits key and command fields when absent', () => {
+    const container = document.createElement('div');
+    container.id = 'apps-list';
+    addRow(container, 'エディタ', 'code.exe', '', '');
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectApps(collected);
+
+    expect(collected.apps['エディタ']).toEqual({ process: 'code.exe' });
+    expect(collected.apps['エディタ']).not.toHaveProperty('key');
+    expect(collected.apps['エディタ']).not.toHaveProperty('command');
+  });
+
+  it('skips a row when the name is empty', () => {
+    const container = document.createElement('div');
+    container.id = 'apps-list';
+    addRow(container, '   ', 'chrome.exe', 'chrome');
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectApps(collected);
+
+    expect(Object.keys(collected.apps)).toHaveLength(0);
+  });
+
+  it('skips a row when no process is selected', () => {
+    const container = document.createElement('div');
+    container.id = 'apps-list';
+    addRow(container, 'なし', '', '');
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectApps(collected);
+
+    expect(Object.keys(collected.apps)).toHaveLength(0);
+  });
+
+  it('skips a row missing one of the required elements', () => {
+    const container = document.createElement('div');
+    container.id = 'apps-list';
+    const row = document.createElement('div');
+    row.className = 'list-row';
+    // .app-select が無い不完全な行 (continue 分岐を pin する)
+    row.innerHTML = `
+      <select class="dispatch-key-select"><option value=""></option></select>
+      <input type="text" class="key-input" value="NoAppSelect">
+    `;
+    container.appendChild(row);
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    expect(() => collectApps(collected)).not.toThrow();
+    expect(Object.keys(collected.apps)).toHaveLength(0);
+  });
+
+  it('renames the duplicate entry using the selected option label to avoid overwriting', () => {
+    // 同名の機能名が 2 行あるとき、2 行目は "name (appLabel)" にリネームされる
+    // (IndexMap のキー重複上書き回避、Issue コメント参照)。
+    const container = document.createElement('div');
+    container.id = 'apps-list';
+    addRow(container, '共通', 'chrome.exe', 'chrome', '', 'Chrome');
+    addRow(container, '共通', 'firefox.exe', 'firefox', '', 'Firefox');
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectApps(collected);
+
+    expect(Object.keys(collected.apps)).toEqual(['共通', '共通 (Firefox)']);
+    expect(collected.apps['共通 (Firefox)']).toEqual({
+      process: 'firefox.exe',
+      command: 'firefox',
+    });
+  });
+
+  it('uses an empty label when the duplicate option has no text content (textContent is "" not nullish)', () => {
+    // selectedOpt?.textContent は要素があれば常に string ('' を含む) を返すため、
+    // `?? process` フォールバックは textContent が空文字のケースでは発動しない
+    // (undefined/null のときだけ発動する nullish coalescing の挙動を pin する)。
+    const container = document.createElement('div');
+    container.id = 'apps-list';
+    const row1 = document.createElement('div');
+    row1.className = 'list-row';
+    row1.innerHTML = `
+      <select class="dispatch-key-select"><option value=""></option></select>
+      <input type="text" class="key-input" value="共通">
+      <select class="app-select"><option value="proc1" data-command=""></option></select>
+    `;
+    const row2 = document.createElement('div');
+    row2.className = 'list-row';
+    row2.innerHTML = `
+      <select class="dispatch-key-select"><option value=""></option></select>
+      <input type="text" class="key-input" value="共通">
+      <select class="app-select"><option value="proc2" data-command=""></option></select>
+    `;
+    container.appendChild(row1);
+    container.appendChild(row2);
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectApps(collected);
+
+    expect(Object.keys(collected.apps)).toEqual(['共通', '共通 ()']);
+  });
+
+  it('collects multiple non-duplicate rows independently', () => {
+    const container = document.createElement('div');
+    container.id = 'apps-list';
+    addRow(container, 'ブラウザ', 'chrome.exe', 'chrome', 'a', 'Chrome');
+    addRow(container, 'メール', 'outlook.exe', 'outlook', 's', 'Outlook');
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectApps(collected);
+
+    expect(Object.keys(collected.apps)).toEqual(['ブラウザ', 'メール']);
+    expect(collected.apps['メール']?.key).toBe('s');
+  });
+
+  it('does nothing when the #apps-list container is absent', () => {
+    const collected = emptyCollected();
+    expect(() => collectApps(collected)).not.toThrow();
+    expect(Object.keys(collected.apps)).toHaveLength(0);
+  });
+});
+
+const APP_PRESETS: AppPresetMap = {
+  ブラウザ: [
+    { label: 'Chrome', process: 'chrome.exe', command: 'chrome' },
+    { label: 'Firefox', process: 'firefox.exe', command: 'firefox' },
+  ],
+};
+
+function makeConfig(apps: Config['apps']): Config {
+  return {
+    search: {},
+    folders: {},
+    apps,
+    timestamp: { format: '%Y%m%d', position: 'before', delimiter: '_' },
+    punctuation_style: '、。',
+  };
+}
+
+describe('createAppSelect', () => {
+  afterEach(() => {
+    setAppPresets({});
+  });
+
+  it('creates a <select> with only the "—" placeholder when there are no presets and no current process', () => {
+    const select = createAppSelect();
+    expect(select.className).toBe('app-select');
+    expect(select.options).toHaveLength(1);
+    expect(select.options[0]?.value).toBe('');
+    expect(select.options[0]?.textContent).toBe('—');
+    expect(select.value).toBe('');
+  });
+
+  it('builds an optgroup per category with options carrying the command in dataset', () => {
+    setAppPresets(APP_PRESETS);
+    const select = createAppSelect('firefox.exe', 'firefox');
+
+    const group = select.querySelector('optgroup');
+    expect(group?.label).toBe('ブラウザ');
+    expect(select.querySelectorAll('option')).toHaveLength(3); // "—" + Chrome + Firefox
+    expect(select.value).toBe('firefox.exe');
+    const firefoxOpt = Array.from(select.options).find((o) => o.value === 'firefox.exe');
+    expect(firefoxOpt?.dataset['command']).toBe('firefox');
+    expect(firefoxOpt?.textContent).toBe('Firefox');
+  });
+
+  it('appends a custom option when currentProcess is not among the presets', () => {
+    setAppPresets(APP_PRESETS);
+    const select = createAppSelect('custom.exe', 'custom-cmd');
+
+    const customOpt = Array.from(select.options).find((o) => o.value === 'custom.exe');
+    expect(customOpt?.textContent).toBe('custom.exe（カスタム）');
+    expect(customOpt?.dataset['command']).toBe('custom-cmd');
+    expect(select.value).toBe('custom.exe');
+  });
+
+  it('falls back to the lowercased process name as the command when currentCommand is empty', () => {
+    setAppPresets(APP_PRESETS);
+    const select = createAppSelect('Custom.EXE', '');
+
+    const customOpt = Array.from(select.options).find((o) => o.value === 'Custom.EXE');
+    expect(customOpt?.dataset['command']).toBe('custom.exe');
+  });
+});
+
+describe('renderAppsList', () => {
+  afterEach(() => {
+    resetConfig();
+  });
+
+  it('returns early without throwing when no config is set', () => {
+    const container = document.createElement('div');
+    container.id = 'apps-list';
+    document.body.appendChild(container);
+
+    resetConfig();
+    expect(() => renderAppsList()).not.toThrow();
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('returns early without throwing when the #apps-list container is absent', () => {
+    setConfig(makeConfig({ ブラウザ: { process: 'chrome.exe' } }));
+    expect(() => renderAppsList()).not.toThrow();
+  });
+
+  it('renders one row per configured app entry, with and without key/command', () => {
+    setConfig(
+      makeConfig({
+        ブラウザ: { process: 'chrome.exe', command: 'chrome', key: 'a' },
+        エディタ: { process: 'code.exe' },
+      }),
+    );
+    const container = document.createElement('div');
+    container.id = 'apps-list';
+    document.body.appendChild(container);
+
+    renderAppsList();
+
+    const rows = container.querySelectorAll('.list-row');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.querySelector<HTMLInputElement>('.key-input')?.value).toBe('ブラウザ');
+    expect(rows[0]?.querySelector<HTMLSelectElement>('.dispatch-key-select')?.value).toBe('a');
+  });
+
+  it('clears any previously rendered rows before re-rendering', () => {
+    setConfig(makeConfig({ ブラウザ: { process: 'chrome.exe' } }));
+    const container = document.createElement('div');
+    container.id = 'apps-list';
+    container.innerHTML = '<div class="list-row stale"></div>';
+    document.body.appendChild(container);
+
+    renderAppsList();
+
+    expect(container.querySelectorAll('.list-row.stale')).toHaveLength(0);
+    expect(container.querySelectorAll('.list-row')).toHaveLength(1);
+  });
+});
+
+describe('addAppRow', () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockReset();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    setAppPresets({});
+  });
+
+  it('appends a row with key-input, app-select and dispatch-key-select prefilled', () => {
+    setAppPresets(APP_PRESETS);
+    const container = document.createElement('div');
+    addAppRow(container, 'ブラウザ', 'chrome.exe', 'chrome', 'a');
+
+    const row = container.querySelector('.list-row');
+    expect(row?.querySelector<HTMLInputElement>('.key-input')?.value).toBe('ブラウザ');
+    expect(row?.querySelector<HTMLSelectElement>('.app-select')?.value).toBe('chrome.exe');
+    expect(row?.querySelector<HTMLSelectElement>('.dispatch-key-select')?.value).toBe('a');
+  });
+
+  it('removes the row when the remove button is clicked', () => {
+    const container = document.createElement('div');
+    addAppRow(container);
+    expect(container.querySelectorAll('.list-row')).toHaveLength(1);
+
+    container.querySelector<HTMLButtonElement>('.btn-remove')?.click();
+
+    expect(container.querySelectorAll('.list-row')).toHaveLength(0);
+  });
+
+  it('renames the row to "category (label)" when an optgroup option is selected', () => {
+    setAppPresets(APP_PRESETS);
+    const container = document.createElement('div');
+    addAppRow(container);
+    const row = container.querySelector('.list-row') as HTMLElement;
+    const appSelect = row.querySelector<HTMLSelectElement>('.app-select');
+    const nameInput = row.querySelector<HTMLInputElement>('.key-input');
+    if (!appSelect || !nameInput) throw new Error('missing elements');
+
+    appSelect.value = 'chrome.exe';
+    appSelect.dispatchEvent(new Event('change'));
+
+    expect(nameInput.value).toBe('ブラウザ (Chrome)');
+  });
+
+  it('leaves the name input untouched when the selected option is not inside an optgroup', () => {
+    setAppPresets(APP_PRESETS);
+    const container = document.createElement('div');
+    addAppRow(container, '既存の名前');
+    const row = container.querySelector('.list-row') as HTMLElement;
+    const appSelect = row.querySelector<HTMLSelectElement>('.app-select');
+    const nameInput = row.querySelector<HTMLInputElement>('.key-input');
+    if (!appSelect || !nameInput) throw new Error('missing elements');
+
+    appSelect.value = ''; // "—" は optgroup の外
+    appSelect.dispatchEvent(new Event('change'));
+
+    expect(nameInput.value).toBe('既存の名前');
+  });
+
+  it('adds and selects a new custom option when a not-yet-listed process is picked', async () => {
+    vi.mocked(invoke).mockResolvedValueOnce([{ name: 'MyApp.exe', pid: 123 }]);
+    const container = document.createElement('div');
+    addAppRow(container);
+    document.body.appendChild(container);
+
+    container.querySelector<HTMLButtonElement>('.btn-pick-process')?.click();
+    await flushMicrotasks();
+
+    const item = document.querySelector<HTMLLIElement>('.modal-list li');
+    expect(item?.textContent).toBe('MyApp.exe');
+    item?.click();
+    await flushMicrotasks();
+
+    const appSelect = container.querySelector<HTMLSelectElement>('.app-select');
+    expect(appSelect?.value).toBe('MyApp');
+    const customOpt = Array.from(appSelect?.options ?? []).find((o) => o.value === 'MyApp');
+    expect(customOpt?.textContent).toBe('MyApp（カスタム）');
+  });
+
+  it('selects an already-listed option without duplicating it when picked', async () => {
+    // showProcessPicker は選択時に ".exe" を除去するため、既存オプションと一致
+    // させるには拡張子なしのプロセス名を使う必要がある。
+    setAppPresets({
+      ツール: [{ label: 'MyTool', process: 'mytool', command: 'mytool' }],
+    });
+    vi.mocked(invoke).mockResolvedValueOnce([{ name: 'mytool', pid: 1 }]);
+    const container = document.createElement('div');
+    addAppRow(container);
+    document.body.appendChild(container);
+
+    const optionsBefore = container.querySelector<HTMLSelectElement>('.app-select')?.options.length;
+
+    container.querySelector<HTMLButtonElement>('.btn-pick-process')?.click();
+    await flushMicrotasks();
+    document.querySelector<HTMLLIElement>('.modal-list li')?.click();
+    await flushMicrotasks();
+
+    const appSelect = container.querySelector<HTMLSelectElement>('.app-select');
+    expect(appSelect?.value).toBe('mytool');
+    expect(appSelect?.options.length).toBe(optionsBefore);
+  });
+
+  it('leaves the app-select untouched when the process picker is cancelled', async () => {
+    vi.mocked(invoke).mockResolvedValueOnce([{ name: 'MyApp.exe', pid: 123 }]);
+    const container = document.createElement('div');
+    addAppRow(container);
+    document.body.appendChild(container);
+
+    container.querySelector<HTMLButtonElement>('.btn-pick-process')?.click();
+    await flushMicrotasks();
+    document.querySelector<HTMLButtonElement>('.btn-cancel')?.click();
+    await flushMicrotasks();
+
+    expect(container.querySelector<HTMLSelectElement>('.app-select')?.value).toBe('');
+  });
+});
+
+describe('showProcessPicker', () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockReset();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('resolves to null and logs an error when invoke rejects', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(invoke).mockRejectedValueOnce(new Error('failed'));
+
+    const result = await showProcessPicker();
+
+    expect(result).toBeNull();
+    expect(consoleError).toHaveBeenCalledWith('プロセス一覧の取得に失敗:', expect.any(Error));
+    consoleError.mockRestore();
+  });
+
+  it('filters the process list by name (case-insensitive) and strips .exe on selection', async () => {
+    vi.mocked(invoke).mockResolvedValueOnce([
+      { name: 'Chrome.EXE', pid: 1 },
+      { name: 'firefox', pid: 2 },
+    ]);
+
+    const pending = showProcessPicker();
+    await flushMicrotasks();
+
+    const searchInput = document.querySelector<HTMLInputElement>('.modal-search');
+    expect(document.querySelectorAll('.modal-list li')).toHaveLength(2);
+
+    if (searchInput) searchInput.value = 'chrome';
+    searchInput?.dispatchEvent(new Event('input'));
+    const items = document.querySelectorAll<HTMLLIElement>('.modal-list li');
+    expect(items).toHaveLength(1);
+
+    items[0]?.click();
+    expect(await pending).toBe('Chrome'); // .exe が除去される
+  });
+
+  it('resolves to null when cancelled', async () => {
+    vi.mocked(invoke).mockResolvedValueOnce([]);
+    const pending = showProcessPicker();
+    await flushMicrotasks();
+    document.querySelector<HTMLButtonElement>('.btn-cancel')?.click();
+    expect(await pending).toBeNull();
+  });
+});
+
+describe('initAppsForm', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('adds a new row to #apps-list when #btn-add-app is clicked', () => {
+    document.body.innerHTML = `
+      <button id="btn-add-app"></button>
+      <div id="apps-list"></div>
+    `;
+    initAppsForm();
+
+    document.getElementById('btn-add-app')?.dispatchEvent(new Event('click'));
+
+    expect(document.querySelectorAll('#apps-list .list-row')).toHaveLength(1);
+  });
+
+  it('does nothing when the button or list element is missing', () => {
+    document.body.innerHTML = `<button id="btn-add-app"></button>`;
+    expect(() => initAppsForm()).not.toThrow();
+  });
+});

--- a/muhenkan-switch/frontend/src/forms/__tests__/folders.test.ts
+++ b/muhenkan-switch/frontend/src/forms/__tests__/folders.test.ts
@@ -1,0 +1,303 @@
+// folders.ts のテスト。collectTimestamp / collectSearch のテストと同型の DOM
+// 組み立てパターンに加え、renderFoldersList / addFolderRow / initFoldersForm も
+// 含めて coverage.include の per-file 80% 閾値を満たす。
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { addFolderRow, collectFolders, initFoldersForm, renderFoldersList } from '../folders';
+import { invoke } from '../../lib/tauri';
+import { resetConfig, setConfig } from '../../lib/state';
+import type { CollectedConfig } from '../../lib/config-io';
+import type { Config, TimestampConfig } from '../../lib/config';
+
+vi.mock('../../lib/tauri', () => ({
+  invoke: vi.fn(),
+}));
+
+function emptyCollected(): CollectedConfig {
+  return {
+    search: {},
+    folders: {},
+    apps: {},
+    timestamp: {} as TimestampConfig,
+    punctuation_style: '、。',
+  };
+}
+
+function addRow(container: HTMLElement, name: string, path: string, dispatchKey = ''): void {
+  const row = document.createElement('div');
+  row.className = 'list-row';
+  row.innerHTML = `
+    <select class="dispatch-key-select"><option value="${dispatchKey}" selected>${dispatchKey}</option></select>
+    <input type="text" class="key-input" value="${name}">
+    <input type="text" class="path-input" value="${path}">
+  `;
+  container.appendChild(row);
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('collectFolders', () => {
+  it('collects a row with name, path and dispatch key', () => {
+    const container = document.createElement('div');
+    container.id = 'folders-list';
+    addRow(container, 'Documents', '~/Documents', 'a');
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectFolders(collected);
+
+    expect(collected.folders['Documents']).toEqual({ path: '~/Documents', key: 'a' });
+  });
+
+  it('omits the key field when no dispatch key is selected', () => {
+    const container = document.createElement('div');
+    container.id = 'folders-list';
+    addRow(container, 'Downloads', '~/Downloads', '');
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectFolders(collected);
+
+    expect(collected.folders['Downloads']).toEqual({ path: '~/Downloads' });
+    expect(collected.folders['Downloads']).not.toHaveProperty('key');
+  });
+
+  it('trims whitespace from the name but preserves the path value as-is except surrounding trim', () => {
+    const container = document.createElement('div');
+    container.id = 'folders-list';
+    addRow(container, '  Documents  ', '  ~/Documents  ', '');
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectFolders(collected);
+
+    expect(Object.keys(collected.folders)).toEqual(['Documents']);
+    expect(collected.folders['Documents']?.path).toBe('~/Documents');
+  });
+
+  it('still collects an entry with an empty path as long as the name is present', () => {
+    // folders.ts の実装は `if (name)` のみをガードにしており、
+    // path が空でも entry を作る (search.ts / apps.ts と異なる非対称仕様)。
+    const container = document.createElement('div');
+    container.id = 'folders-list';
+    addRow(container, 'Empty', '   ', '');
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectFolders(collected);
+
+    expect(collected.folders['Empty']).toEqual({ path: '' });
+  });
+
+  it('skips a row when the name is empty', () => {
+    const container = document.createElement('div');
+    container.id = 'folders-list';
+    addRow(container, '   ', '~/Documents', '');
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectFolders(collected);
+
+    expect(Object.keys(collected.folders)).toHaveLength(0);
+  });
+
+  it('skips a row missing one of the required inputs', () => {
+    const container = document.createElement('div');
+    container.id = 'folders-list';
+    const row = document.createElement('div');
+    row.className = 'list-row';
+    // .path-input が無い不完全な行 (continue 分岐を pin する)
+    row.innerHTML = `
+      <select class="dispatch-key-select"><option value=""></option></select>
+      <input type="text" class="key-input" value="NoPath">
+    `;
+    container.appendChild(row);
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    expect(() => collectFolders(collected)).not.toThrow();
+    expect(Object.keys(collected.folders)).toHaveLength(0);
+  });
+
+  it('collects multiple rows independently', () => {
+    const container = document.createElement('div');
+    container.id = 'folders-list';
+    addRow(container, 'Documents', '~/Documents', 'a');
+    addRow(container, 'Downloads', '~/Downloads', 's');
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectFolders(collected);
+
+    expect(Object.keys(collected.folders)).toEqual(['Documents', 'Downloads']);
+    expect(collected.folders['Downloads']?.key).toBe('s');
+  });
+
+  it('does nothing when the #folders-list container is absent', () => {
+    const collected = emptyCollected();
+    expect(() => collectFolders(collected)).not.toThrow();
+    expect(Object.keys(collected.folders)).toHaveLength(0);
+  });
+});
+
+function makeConfig(folders: Config['folders']): Config {
+  return {
+    search: {},
+    folders,
+    apps: {},
+    timestamp: { format: '%Y%m%d', position: 'before', delimiter: '_' },
+    punctuation_style: '、。',
+  };
+}
+
+describe('renderFoldersList', () => {
+  afterEach(() => {
+    resetConfig();
+  });
+
+  it('returns early without throwing when no config is set', () => {
+    const container = document.createElement('div');
+    container.id = 'folders-list';
+    document.body.appendChild(container);
+
+    resetConfig();
+    expect(() => renderFoldersList()).not.toThrow();
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('returns early without throwing when the #folders-list container is absent', () => {
+    setConfig(makeConfig({ Documents: { path: '~/Documents' } }));
+    expect(() => renderFoldersList()).not.toThrow();
+  });
+
+  it('renders one row per configured folder entry, with and without a dispatch key', () => {
+    setConfig(
+      makeConfig({
+        Documents: { path: '~/Documents', key: 'a' },
+        Downloads: { path: '~/Downloads' },
+      }),
+    );
+    const container = document.createElement('div');
+    container.id = 'folders-list';
+    document.body.appendChild(container);
+
+    renderFoldersList();
+
+    const rows = container.querySelectorAll('.list-row');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.querySelector<HTMLInputElement>('.key-input')?.value).toBe('Documents');
+    expect(rows[0]?.querySelector<HTMLInputElement>('.path-input')?.value).toBe('~/Documents');
+    expect(rows[0]?.querySelector<HTMLSelectElement>('.dispatch-key-select')?.value).toBe('a');
+  });
+
+  it('clears any previously rendered rows before re-rendering', () => {
+    setConfig(makeConfig({ Documents: { path: '~/Documents' } }));
+    const container = document.createElement('div');
+    container.id = 'folders-list';
+    container.innerHTML = '<div class="list-row stale"></div>';
+    document.body.appendChild(container);
+
+    renderFoldersList();
+
+    expect(container.querySelectorAll('.list-row.stale')).toHaveLength(0);
+    expect(container.querySelectorAll('.list-row')).toHaveLength(1);
+  });
+});
+
+describe('addFolderRow', () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockReset();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('appends a row with key-input, path-input and dispatch-key-select prefilled', () => {
+    const container = document.createElement('div');
+    addFolderRow(container, 'Documents', '~/Documents', 'a');
+
+    const row = container.querySelector('.list-row');
+    expect(row).not.toBeNull();
+    expect(row?.querySelector<HTMLInputElement>('.key-input')?.value).toBe('Documents');
+    expect(row?.querySelector<HTMLInputElement>('.path-input')?.value).toBe('~/Documents');
+    expect(row?.querySelector<HTMLSelectElement>('.dispatch-key-select')?.value).toBe('a');
+  });
+
+  it('removes the row when the remove button is clicked', () => {
+    const container = document.createElement('div');
+    addFolderRow(container, 'Documents', '~/Documents');
+    expect(container.querySelectorAll('.list-row')).toHaveLength(1);
+
+    container.querySelector<HTMLButtonElement>('.btn-remove')?.click();
+
+    expect(container.querySelectorAll('.list-row')).toHaveLength(0);
+  });
+
+  it('fills the path input with the folder selected via the browse dialog', async () => {
+    vi.mocked(invoke).mockResolvedValueOnce('/home/user/Selected');
+    const container = document.createElement('div');
+    addFolderRow(container);
+
+    container.querySelector<HTMLButtonElement>('.btn-browse')?.dispatchEvent(new Event('click'));
+    // click ハンドラは async のため、invoke の解決をまたぐ 1 tick を挟む
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(invoke).toHaveBeenCalledWith('browse_folder');
+    expect(container.querySelector<HTMLInputElement>('.path-input')?.value).toBe(
+      '/home/user/Selected',
+    );
+  });
+
+  it('leaves the path input untouched when the browse dialog is cancelled (null)', async () => {
+    vi.mocked(invoke).mockResolvedValueOnce(null);
+    const container = document.createElement('div');
+    addFolderRow(container, '', 'original');
+
+    container.querySelector<HTMLButtonElement>('.btn-browse')?.dispatchEvent(new Event('click'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(container.querySelector<HTMLInputElement>('.path-input')?.value).toBe('original');
+  });
+
+  it('logs an error and leaves the path input untouched when invoke rejects', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(invoke).mockRejectedValueOnce(new Error('dialog failed'));
+    const container = document.createElement('div');
+    addFolderRow(container, '', 'original');
+
+    container.querySelector<HTMLButtonElement>('.btn-browse')?.dispatchEvent(new Event('click'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(container.querySelector<HTMLInputElement>('.path-input')?.value).toBe('original');
+    expect(consoleError).toHaveBeenCalledWith('フォルダ選択に失敗:', expect.any(Error));
+    consoleError.mockRestore();
+  });
+});
+
+describe('initFoldersForm', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('adds a new row to #folders-list when #btn-add-folder is clicked', () => {
+    document.body.innerHTML = `
+      <button id="btn-add-folder"></button>
+      <div id="folders-list"></div>
+    `;
+    initFoldersForm();
+
+    document.getElementById('btn-add-folder')?.dispatchEvent(new Event('click'));
+
+    expect(document.querySelectorAll('#folders-list .list-row')).toHaveLength(1);
+  });
+
+  it('does nothing when the button or list element is missing', () => {
+    document.body.innerHTML = `<button id="btn-add-folder"></button>`;
+    expect(() => initFoldersForm()).not.toThrow();
+  });
+});

--- a/muhenkan-switch/frontend/src/forms/__tests__/search.test.ts
+++ b/muhenkan-switch/frontend/src/forms/__tests__/search.test.ts
@@ -1,0 +1,358 @@
+// search.ts のテスト。collectTimestamp のテスト (timestamp.test.ts) と同型の
+// DOM 組み立てパターンに加え、renderSearchList / addSearchRow / showSearchPicker /
+// initSearchForm も含めて coverage.include の per-file 80% 閾値を満たす。
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  addSearchRow,
+  collectSearch,
+  initSearchForm,
+  renderSearchList,
+  showSearchPicker,
+} from '../search';
+import { resetConfig, setConfig, setSearchPresets } from '../../lib/state';
+import type { CollectedConfig } from '../../lib/config-io';
+import type { Config, TimestampConfig } from '../../lib/config';
+
+// createPickerModal の Promise executor は同期実行されるため、モーダル起動直後は
+// list 要素まで同期的に DOM へ追加済み。選択後の resolve → 呼び出し側の続き (await の
+// 後続処理) はマイクロタスク経由になるため、明示的にフラッシュする必要がある。
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function emptyCollected(): CollectedConfig {
+  return {
+    search: {},
+    folders: {},
+    apps: {},
+    timestamp: {} as TimestampConfig,
+    punctuation_style: '、。',
+  };
+}
+
+function addRow(container: HTMLElement, name: string, url: string, dispatchKey = ''): void {
+  const row = document.createElement('div');
+  row.className = 'list-row';
+  row.innerHTML = `
+    <select class="dispatch-key-select"><option value="${dispatchKey}" selected>${dispatchKey}</option></select>
+    <input type="text" class="key-input" value="${name}">
+    <input type="text" class="url-input" value="${url}">
+  `;
+  container.appendChild(row);
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('collectSearch', () => {
+  it('collects a row with name, url and dispatch key', () => {
+    const container = document.createElement('div');
+    container.id = 'search-list';
+    addRow(container, 'Google', 'https://google.com/search?q={query}', 'q');
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectSearch(collected);
+
+    expect(collected.search['Google']).toEqual({
+      url: 'https://google.com/search?q={query}',
+      key: 'q',
+    });
+  });
+
+  it('omits the key field when no dispatch key is selected', () => {
+    const container = document.createElement('div');
+    container.id = 'search-list';
+    addRow(container, 'Bing', 'https://bing.com/search?q={query}', '');
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectSearch(collected);
+
+    expect(collected.search['Bing']).toEqual({ url: 'https://bing.com/search?q={query}' });
+    expect(collected.search['Bing']).not.toHaveProperty('key');
+  });
+
+  it('trims whitespace from name and url before collecting', () => {
+    const container = document.createElement('div');
+    container.id = 'search-list';
+    addRow(container, '  Google  ', '  https://google.com  ', '');
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectSearch(collected);
+
+    expect(Object.keys(collected.search)).toEqual(['Google']);
+    expect(collected.search['Google']?.url).toBe('https://google.com');
+  });
+
+  it('skips a row when the name is empty', () => {
+    const container = document.createElement('div');
+    container.id = 'search-list';
+    addRow(container, '   ', 'https://example.com', '');
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectSearch(collected);
+
+    expect(Object.keys(collected.search)).toHaveLength(0);
+  });
+
+  it('skips a row when the url is empty', () => {
+    const container = document.createElement('div');
+    container.id = 'search-list';
+    addRow(container, 'Empty', '   ', '');
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectSearch(collected);
+
+    expect(Object.keys(collected.search)).toHaveLength(0);
+  });
+
+  it('skips a row missing one of the required inputs', () => {
+    const container = document.createElement('div');
+    container.id = 'search-list';
+    const row = document.createElement('div');
+    row.className = 'list-row';
+    // .url-input が無い不完全な行 (continue 分岐を pin する)
+    row.innerHTML = `
+      <select class="dispatch-key-select"><option value=""></option></select>
+      <input type="text" class="key-input" value="NoUrl">
+    `;
+    container.appendChild(row);
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    expect(() => collectSearch(collected)).not.toThrow();
+    expect(Object.keys(collected.search)).toHaveLength(0);
+  });
+
+  it('collects multiple rows independently', () => {
+    const container = document.createElement('div');
+    container.id = 'search-list';
+    addRow(container, 'Google', 'https://google.com/{query}', 'q');
+    addRow(container, 'Bing', 'https://bing.com/{query}', 'w');
+    document.body.appendChild(container);
+
+    const collected = emptyCollected();
+    collectSearch(collected);
+
+    expect(Object.keys(collected.search)).toEqual(['Google', 'Bing']);
+    expect(collected.search['Bing']?.key).toBe('w');
+  });
+
+  it('does nothing when the #search-list container is absent', () => {
+    const collected = emptyCollected();
+    expect(() => collectSearch(collected)).not.toThrow();
+    expect(Object.keys(collected.search)).toHaveLength(0);
+  });
+});
+
+function makeConfig(search: Config['search']): Config {
+  return {
+    search,
+    folders: {},
+    apps: {},
+    timestamp: { format: '%Y%m%d', position: 'before', delimiter: '_' },
+    punctuation_style: '、。',
+  };
+}
+
+describe('renderSearchList', () => {
+  afterEach(() => {
+    resetConfig();
+  });
+
+  it('returns early without throwing when no config is set', () => {
+    const container = document.createElement('div');
+    container.id = 'search-list';
+    document.body.appendChild(container);
+
+    resetConfig();
+    expect(() => renderSearchList()).not.toThrow();
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('returns early without throwing when the #search-list container is absent', () => {
+    setConfig(makeConfig({ Google: { url: 'https://google.com/{query}' } }));
+    expect(() => renderSearchList()).not.toThrow();
+  });
+
+  it('renders one row per configured search entry, with and without a dispatch key', () => {
+    setConfig(
+      makeConfig({
+        Google: { url: 'https://google.com/{query}', key: 'q' },
+        Bing: { url: 'https://bing.com/{query}' },
+      }),
+    );
+    const container = document.createElement('div');
+    container.id = 'search-list';
+    document.body.appendChild(container);
+
+    renderSearchList();
+
+    const rows = container.querySelectorAll('.list-row');
+    expect(rows).toHaveLength(2);
+    const firstName = rows[0]?.querySelector<HTMLInputElement>('.key-input');
+    const firstUrl = rows[0]?.querySelector<HTMLInputElement>('.url-input');
+    const firstKey = rows[0]?.querySelector<HTMLSelectElement>('.dispatch-key-select');
+    expect(firstName?.value).toBe('Google');
+    expect(firstUrl?.value).toBe('https://google.com/{query}');
+    expect(firstKey?.value).toBe('q');
+  });
+
+  it('clears any previously rendered rows before re-rendering', () => {
+    setConfig(makeConfig({ Google: { url: 'https://google.com/{query}' } }));
+    const container = document.createElement('div');
+    container.id = 'search-list';
+    container.innerHTML = '<div class="list-row stale"></div>';
+    document.body.appendChild(container);
+
+    renderSearchList();
+
+    expect(container.querySelectorAll('.list-row.stale')).toHaveLength(0);
+    expect(container.querySelectorAll('.list-row')).toHaveLength(1);
+  });
+});
+
+describe('addSearchRow', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    setSearchPresets({});
+  });
+
+  it('appends a row with key-input, url-input and dispatch-key-select prefilled', () => {
+    const container = document.createElement('div');
+    addSearchRow(container, 'Google', 'https://google.com/{query}', 'q');
+
+    const row = container.querySelector('.list-row');
+    expect(row).not.toBeNull();
+    expect(row?.querySelector<HTMLInputElement>('.key-input')?.value).toBe('Google');
+    expect(row?.querySelector<HTMLInputElement>('.url-input')?.value).toBe(
+      'https://google.com/{query}',
+    );
+    expect(row?.querySelector<HTMLSelectElement>('.dispatch-key-select')?.value).toBe('q');
+  });
+
+  it('removes the row when the remove button is clicked', () => {
+    const container = document.createElement('div');
+    addSearchRow(container, 'Google', 'https://google.com/{query}');
+    expect(container.querySelectorAll('.list-row')).toHaveLength(1);
+
+    container.querySelector<HTMLButtonElement>('.btn-remove')?.click();
+
+    expect(container.querySelectorAll('.list-row')).toHaveLength(0);
+  });
+
+  it('fills name/url from the selected preset when the pick button is used', async () => {
+    setSearchPresets({
+      検索: [{ label: 'Google', url: 'https://google.com/search?q={query}' }],
+    });
+    const container = document.createElement('div');
+    addSearchRow(container);
+    document.body.appendChild(container);
+
+    container.querySelector<HTMLButtonElement>('.btn-pick-search')?.click();
+
+    const item = document.querySelector<HTMLLIElement>('.modal-list li:not(.modal-list-header)');
+    expect(item?.textContent).toBe('Google');
+    item?.click();
+    await flushMicrotasks();
+
+    expect(container.querySelector<HTMLInputElement>('.key-input')?.value).toBe('Google');
+    expect(container.querySelector<HTMLInputElement>('.url-input')?.value).toBe(
+      'https://google.com/search?q={query}',
+    );
+  });
+
+  it('leaves the inputs untouched when the picker is cancelled', async () => {
+    setSearchPresets({
+      検索: [{ label: 'Google', url: 'https://google.com/search?q={query}' }],
+    });
+    const container = document.createElement('div');
+    addSearchRow(container);
+    document.body.appendChild(container);
+
+    container.querySelector<HTMLButtonElement>('.btn-pick-search')?.click();
+    document.querySelector<HTMLButtonElement>('.btn-cancel')?.click();
+    await flushMicrotasks();
+
+    expect(container.querySelector<HTMLInputElement>('.key-input')?.value).toBe('');
+    expect(container.querySelector<HTMLInputElement>('.url-input')?.value).toBe('');
+  });
+});
+
+describe('showSearchPicker', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    setSearchPresets({});
+  });
+
+  it('groups presets by category and filters by label or category (case-insensitive)', async () => {
+    setSearchPresets({
+      検索エンジン: [
+        { label: 'Google', url: 'https://google.com/{query}' },
+        { label: 'Bing', url: 'https://bing.com/{query}' },
+      ],
+      辞書: [{ label: 'Weblio', url: 'https://weblio.jp/{query}' }],
+    });
+
+    const pending = showSearchPicker();
+    const searchInput = document.querySelector<HTMLInputElement>('.modal-search');
+    expect(searchInput).not.toBeNull();
+
+    // 初期表示は全カテゴリ・全件
+    expect(document.querySelectorAll('.modal-list-header')).toHaveLength(2);
+    expect(document.querySelectorAll('.modal-list li:not(.modal-list-header)')).toHaveLength(3);
+
+    // ラベルでフィルタ (大文字小文字を無視)
+    if (searchInput) searchInput.value = 'GOOGLE';
+    searchInput?.dispatchEvent(new Event('input'));
+    let items = document.querySelectorAll<HTMLLIElement>('.modal-list li:not(.modal-list-header)');
+    expect(items).toHaveLength(1);
+    expect(items[0]?.textContent).toBe('Google');
+
+    // カテゴリ名でフィルタ
+    if (searchInput) searchInput.value = '辞書';
+    searchInput?.dispatchEvent(new Event('input'));
+    items = document.querySelectorAll<HTMLLIElement>('.modal-list li:not(.modal-list-header)');
+    expect(items).toHaveLength(1);
+    expect(items[0]?.textContent).toBe('Weblio');
+
+    items[0]?.click();
+    const result = await pending;
+    expect(result).toEqual({ label: 'Weblio', url: 'https://weblio.jp/{query}' });
+  });
+
+  it('resolves to null when cancelled', async () => {
+    setSearchPresets({ 検索: [{ label: 'Google', url: 'https://google.com/{query}' }] });
+    const pending = showSearchPicker();
+    document.querySelector<HTMLButtonElement>('.btn-cancel')?.click();
+    expect(await pending).toBeNull();
+  });
+});
+
+describe('initSearchForm', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('adds a new row to #search-list when #btn-add-search is clicked', () => {
+    document.body.innerHTML = `
+      <button id="btn-add-search"></button>
+      <div id="search-list"></div>
+    `;
+    initSearchForm();
+
+    document.getElementById('btn-add-search')?.dispatchEvent(new Event('click'));
+
+    expect(document.querySelectorAll('#search-list .list-row')).toHaveLength(1);
+  });
+
+  it('does nothing when the button or list element is missing', () => {
+    document.body.innerHTML = `<button id="btn-add-search"></button>`;
+    expect(() => initSearchForm()).not.toThrow();
+  });
+});

--- a/muhenkan-switch/frontend/src/lib/__tests__/dom-utils.test.ts
+++ b/muhenkan-switch/frontend/src/lib/__tests__/dom-utils.test.ts
@@ -1,0 +1,31 @@
+// dom-utils.ts の requireEl テスト
+import { afterEach, describe, expect, it } from 'vitest';
+import { requireEl } from '../dom-utils';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('requireEl', () => {
+  it('returns the element when it exists', () => {
+    const el = document.createElement('div');
+    el.id = 'existing';
+    document.body.appendChild(el);
+
+    expect(requireEl<HTMLDivElement>('existing')).toBe(el);
+  });
+
+  it('throws a descriptive error when the element does not exist', () => {
+    expect(() => requireEl('missing')).toThrow('Required element #missing not found');
+  });
+
+  it('returns a typed element usable as the requested HTMLElement subtype', () => {
+    const input = document.createElement('input');
+    input.id = 'ts-format-custom';
+    input.value = 'hello';
+    document.body.appendChild(input);
+
+    const found = requireEl<HTMLInputElement>('ts-format-custom');
+    expect(found.value).toBe('hello');
+  });
+});

--- a/muhenkan-switch/frontend/src/lib/__tests__/state.test.ts
+++ b/muhenkan-switch/frontend/src/lib/__tests__/state.test.ts
@@ -1,0 +1,85 @@
+// state.ts の getter / setter テスト (元 main.js の module-level `let` 相当)
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  DISPATCH_KEYS,
+  getAppPresets,
+  getConfig,
+  getSearchPresets,
+  resetConfig,
+  setAppPresets,
+  setConfig,
+  setSearchPresets,
+} from '../state';
+import type { Config } from '../config';
+import type { AppPresetMap, SearchPresetMap } from '../state';
+
+function makeConfig(): Config {
+  return {
+    search: {},
+    folders: {},
+    apps: {},
+    timestamp: { format: '%Y%m%d', position: 'before', delimiter: '_' },
+    punctuation_style: '、。',
+  };
+}
+
+afterEach(() => {
+  resetConfig();
+  setAppPresets({});
+  setSearchPresets({});
+});
+
+describe('config getter/setter', () => {
+  it('returns null before any config has been set', () => {
+    expect(getConfig()).toBeNull();
+  });
+
+  it('returns the value passed to setConfig', () => {
+    const config = makeConfig();
+    setConfig(config);
+    expect(getConfig()).toBe(config);
+  });
+
+  it('resetConfig clears the stored config back to null', () => {
+    setConfig(makeConfig());
+    resetConfig();
+    expect(getConfig()).toBeNull();
+  });
+});
+
+describe('app presets getter/setter', () => {
+  it('starts as an empty object', () => {
+    expect(getAppPresets()).toEqual({});
+  });
+
+  it('returns the value passed to setAppPresets', () => {
+    const presets: AppPresetMap = {
+      ブラウザ: [{ label: 'Chrome', process: 'chrome.exe', command: 'chrome' }],
+    };
+    setAppPresets(presets);
+    expect(getAppPresets()).toBe(presets);
+  });
+});
+
+describe('search presets getter/setter', () => {
+  it('starts as an empty object', () => {
+    expect(getSearchPresets()).toEqual({});
+  });
+
+  it('returns the value passed to setSearchPresets', () => {
+    const presets: SearchPresetMap = {
+      検索: [{ label: 'Google', url: 'https://google.com/search?q={query}' }],
+    };
+    setSearchPresets(presets);
+    expect(getSearchPresets()).toBe(presets);
+  });
+});
+
+describe('DISPATCH_KEYS', () => {
+  it('contains only unique, lowercase single-character keys', () => {
+    expect(new Set(DISPATCH_KEYS).size).toBe(DISPATCH_KEYS.length);
+    for (const key of DISPATCH_KEYS) {
+      expect(key).toMatch(/^[a-z0-9]$/);
+    }
+  });
+});

--- a/muhenkan-switch/frontend/vitest.config.ts
+++ b/muhenkan-switch/frontend/vitest.config.ts
@@ -21,7 +21,16 @@ export default defineConfig({
       // include は **テスト済ファイル** だけを whitelist。新しいテストを追加した
       // 時は対象ファイルをここに足す。未テストファイルを混ぜず、cover 済の品質
       // 維持を per-file 閾値で強制する設計 (Issue #167)。
-      include: ['src/lib/utils.ts', 'src/lib/dispatch-key.ts', 'src/forms/timestamp.ts'],
+      include: [
+        'src/lib/utils.ts',
+        'src/lib/dispatch-key.ts',
+        'src/lib/dom-utils.ts',
+        'src/lib/state.ts',
+        'src/forms/timestamp.ts',
+        'src/forms/search.ts',
+        'src/forms/folders.ts',
+        'src/forms/apps.ts',
+      ],
       exclude: ['src/**/*.test.ts', 'src/**/__tests__/**'],
       thresholds: {
         perFile: true,

--- a/muhenkan-switch/src/commands.rs
+++ b/muhenkan-switch/src/commands.rs
@@ -691,4 +691,78 @@ mod tests {
         assert_eq!(escape_for_js_template_literal(input), input);
         assert!(!has_unescaped_terminator_or_expr(input));
     }
+
+    // ── validate_timestamp_format ──
+
+    #[test]
+    fn validate_timestamp_format_rejects_empty_format() {
+        let result =
+            validate_timestamp_format("".to_string(), "_".to_string(), "before".to_string());
+        assert_eq!(result, Err("フォーマットを入力してください".to_string()));
+    }
+
+    #[test]
+    fn validate_timestamp_format_places_timestamp_before_the_stem_with_delimiter() {
+        // "LITERAL" は chrono の strftime 指定子を含まないため、そのままリテラル
+        // 出力されることを利用して、現在時刻に依存しない決定的なテストにする。
+        let result =
+            validate_timestamp_format("LITERAL".to_string(), "-".to_string(), "before".to_string());
+        assert_eq!(result, Ok("LITERAL-FileName.txt".to_string()));
+    }
+
+    #[test]
+    fn validate_timestamp_format_places_timestamp_after_the_stem_with_delimiter() {
+        let result =
+            validate_timestamp_format("LITERAL".to_string(), "_".to_string(), "after".to_string());
+        assert_eq!(result, Ok("FileName_LITERAL.txt".to_string()));
+    }
+
+    #[test]
+    fn validate_timestamp_format_supports_an_empty_delimiter() {
+        let result =
+            validate_timestamp_format("LITERAL".to_string(), "".to_string(), "before".to_string());
+        assert_eq!(result, Ok("LITERALFileName.txt".to_string()));
+    }
+
+    #[test]
+    fn validate_timestamp_format_treats_any_non_after_position_as_before() {
+        // position は "before" | "after" の 2値だが、実装は "after" 以外を
+        // 全て before 扱いにするフォールバックになっている。その挙動を pin する。
+        let result = validate_timestamp_format(
+            "LITERAL".to_string(),
+            "_".to_string(),
+            "unexpected".to_string(),
+        );
+        assert_eq!(result, Ok("LITERAL_FileName.txt".to_string()));
+    }
+
+    // ── resolve_config_path ──
+
+    #[test]
+    fn resolve_config_path_always_targets_a_config_toml_file() {
+        // config::config_path() が Some/None どちらであっても、最終的なパスは
+        // 常に "config.toml" を指す（フォールバック時も同じファイル名になる）。
+        let path = resolve_config_path();
+        assert_eq!(
+            path.file_name().and_then(|n| n.to_str()),
+            Some("config.toml")
+        );
+    }
+
+    // ── get_install_type / is_nsis_install ──
+
+    #[test]
+    fn is_nsis_install_matches_windows_target_only() {
+        assert_eq!(is_nsis_install(), cfg!(target_os = "windows"));
+    }
+
+    #[test]
+    fn get_install_type_reports_installer_on_windows_and_script_otherwise() {
+        let expected = if cfg!(target_os = "windows") {
+            "installer"
+        } else {
+            "script"
+        };
+        assert_eq!(get_install_type(), expected);
+    }
 }

--- a/muhenkan-switch/src/kanata.rs
+++ b/muhenkan-switch/src/kanata.rs
@@ -286,13 +286,23 @@ impl KanataManager {
             job.assign(pid);
         }
 
-        // 起動成功。以前の stop() による意図的停止フラグをクリアし、
-        // 監視スレッドが次回のクラッシュを通知できるようにする。
-        self.intentional_stop.store(false, Ordering::SeqCst);
-
-        *guard = Some(Arc::new(child));
+        // 起動成功時の状態更新（intentional_stop リセット + child 保持）。
+        // 実プロセス起動を伴わずに単体テストできるよう別関数へ抽出している (Issue #230)。
+        Self::on_started(&self.intentional_stop, &mut guard, child);
 
         Ok(())
+    }
+
+    /// 起動成功後の状態更新: 以前の `stop()` による意図的停止フラグをクリアし、
+    /// 起動した子プロセスを保持する。監視スレッドが次回のクラッシュを通知できる
+    /// ようにするための処理を `start()` から抽出したもの（挙動は変更していない）。
+    fn on_started(
+        intentional_stop: &AtomicBool,
+        guard: &mut Option<Arc<SharedChild>>,
+        child: SharedChild,
+    ) {
+        intentional_stop.store(false, Ordering::SeqCst);
+        *guard = Some(Arc::new(child));
     }
 
     pub fn stop(&self) -> Result<()> {
@@ -321,13 +331,12 @@ impl KanataManager {
 
 // ── Tests ──
 //
-// start() は実際の kanata バイナリ（bin/kanata_cmd_allowed）が無いと
-// 起動に失敗するため、ここでは start() を伴わずに検証できる
-// intentional_stop フラグの初期値・stop() による更新のみをテストする。
-// start() 成功時のフラグリセット（本 Issue の修正本体）を含む
-// stop → start の完全な状態遷移テストは、実バイナリの用意または
-// プロセス起動を差し替える依存性注入が必要になり invasive なため見送る
-// （テスト整備は Issue #230 で扱う）。
+// start() 全体は実際の kanata バイナリ（bin/kanata_cmd_allowed）が無いと
+// 起動に失敗するため、それ自体は呼ばずに intentional_stop フラグの初期値・
+// stop() による更新をテストする。
+// start() 成功時のフラグリセット（intentional_stop リセット漏れバグの回帰防止）は、
+// その後処理を `on_started()` として抽出したことで、実 kanata バイナリなしに
+// テストできる（本物の子プロセスとして OS 標準のごく短命なコマンドを spawn する）。
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -354,6 +363,56 @@ mod tests {
     fn status_with_no_child_returns_not_running() {
         let manager = KanataManager::new();
         assert_eq!(manager.status(), (false, None));
+    }
+
+    /// kanata バイナリを必要とせず、OS 標準のごく短命なプロセスを spawn して
+    /// SharedChild を用意する（on_started() のテスト専用ヘルパー）。
+    fn spawn_noop_child() -> SharedChild {
+        let mut cmd = if cfg!(windows) {
+            let mut c = std::process::Command::new("cmd");
+            c.args(["/C", "exit 0"]);
+            c
+        } else {
+            std::process::Command::new("true")
+        };
+        SharedChild::spawn(&mut cmd).expect("failed to spawn no-op child process for test")
+    }
+
+    #[test]
+    fn on_started_clears_intentional_stop_flag_previously_set_by_stop() {
+        // 回帰対象のバグ: stop() → start() のとき、start() 成功後も
+        // intentional_stop フラグが true のままだと、監視スレッドが次のクラッシュ
+        // 通知を出せなくなる。on_started() がこれをクリアすることを pin する。
+        let intentional_stop = AtomicBool::new(true); // stop() 済みを模した初期状態
+        let mut guard: Option<Arc<SharedChild>> = None;
+
+        KanataManager::on_started(&intentional_stop, &mut guard, spawn_noop_child());
+
+        assert!(!intentional_stop.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn on_started_stores_the_spawned_child_in_the_guard() {
+        let intentional_stop = AtomicBool::new(false);
+        let mut guard: Option<Arc<SharedChild>> = None;
+
+        KanataManager::on_started(&intentional_stop, &mut guard, spawn_noop_child());
+
+        assert!(guard.is_some());
+    }
+
+    #[test]
+    fn on_started_overwrites_a_previously_stored_child() {
+        let intentional_stop = AtomicBool::new(false);
+        let mut guard: Option<Arc<SharedChild>> = Some(Arc::new(spawn_noop_child()));
+        let new_pid = {
+            let child = spawn_noop_child();
+            let pid = child.id();
+            KanataManager::on_started(&intentional_stop, &mut guard, child);
+            pid
+        };
+
+        assert_eq!(guard.as_ref().map(|c| c.id()), Some(new_pid));
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #230

frontend の `collectSearch` / `collectFolders` / `collectApps` が `collectTimestamp` と同じ構造なのに未テストだった非対称と、`lib/dom-utils.ts` / `lib/state.ts` が `coverage.include` 外だった問題を解消。GUI クレート (`muhenkan-switch/src`) にはテストが皆無だったため、純粋ロジックのユニットテストを追加した。

### frontend (`muhenkan-switch/frontend/`)

- `src/forms/__tests__/search.test.ts` (新規): `collectSearch` / `renderSearchList` / `addSearchRow` / `showSearchPicker` / `initSearchForm`
- `src/forms/__tests__/folders.test.ts` (新規): `collectFolders` / `renderFoldersList` / `addFolderRow` (browse_folder invoke 成功・null・失敗) / `initFoldersForm`
- `src/forms/__tests__/apps.test.ts` (新規): `collectApps` (重複名リネームの非 nullish 挙動含む) / `createAppSelect` / `renderAppsList` / `addAppRow` (プロセス選択・optgroup ラベル反映) / `showProcessPicker` / `initAppsForm`
- `src/lib/__tests__/dom-utils.test.ts` (新規): `requireEl`
- `src/lib/__tests__/state.test.ts` (新規): config / app presets / search presets の getter・setter、`DISPATCH_KEYS`
- `vitest.config.ts`: `coverage.include` に `search.ts` / `folders.ts` / `apps.ts` / `dom-utils.ts` / `state.ts` を追加登録

### GUI クレート (`muhenkan-switch/src/`)

- `commands.rs`: `validate_timestamp_format`（空フォーマット拒否・before/after 配置・空区切り文字・不正 position のフォールバック）、`resolve_config_path`（常に `config.toml` を指す不変条件）、`get_install_type` / `is_nsis_install` のユニットテストを追加
- `kanata.rs`: `KanataManager::start()` の起動成功後処理（`intentional_stop` リセット + child 保持）を `on_started()` として抽出（挙動は変更なし）。これにより実 kanata バイナリなしに OS 標準の短命プロセスを spawn して「stop() → start() で `intentional_stop` フラグがクリアされる」という回帰テストを追加した

## Coverage (frontend, per-file 80% 閾値)

Before (元の `coverage.include` 3 ファイルのみ): 3 test files / 34 tests、対象 3 ファイルは 100%/100%/100%/100%

After: 8 test files / 113 tests、対象 8 ファイル合計 Statements 99.68% (321/322) / Branches 93.58% (146/156) / Functions 100% (55/55) / Lines 100% (291/291)。全ファイルが per-file 80% 閾値を満たす。

## Test plan

- [x] `cd muhenkan-switch/frontend && npm ci && npm run typecheck && npm run lint && npm run format:check && npm run test && npm run build` 全 pass
- [x] `CARGO_TARGET_DIR=... cargo test --workspace` 全 pass（96 tests: muhenkan-switch 19 / muhenkan-switch-config 43 / muhenkan-switch-core 34）