### PR TITLE
release: v0.11.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-config"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-core"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.4"
+version = "0.11.5"
 edition = "2021"
 license = "LGPL-3.0-only"
 repository = "https://github.com/kimushun1101/muhenkan-switch"

--- a/muhenkan-switch/tauri.conf.json
+++ b/muhenkan-switch/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "muhenkan-switch",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "identifier": "com.muhenkan-switch",
   "build": {
     "frontendDist": "./frontend/dist"


### PR DESCRIPTION
## バージョン更新

- Cargo workspace version: 0.11.4 → 0.11.5
- tauri.conf.json version: 0.11.4 → 0.11.5
- Cargo.lock を同期

## v0.11.5 に含まれる主な変更 (v0.11.4 以降)

### 機能・修正
- **自動起動時はメインウィンドウを表示せずバックグラウンド起動** (#215, #238)。既存ユーザーの自動起動登録は初回起動時に自動で `--hidden` 付きへ移行
- トレイ⇔GUI の自動起動チェック双方向同期 (#216, #245)
- kanata クラッシュ通知が設定保存後に無効化される不具合を修正 (#217, #237)
- 機能しない z キー割当を GUI から除去 (#218, #236)
- macOS の更新チェック失敗を修正 (#219, #233)、install/update のレート制限フォールバック (#231, #246)
- **Linux/macOS リリースに config.toml を同梱せず、初回起動時に OS 別デフォルトを自動生成** (#220, #242) ← 挙動変更
- config インポート時の句読点反映・kanata 再起動 (#222, #239)、タイムスタンプ不正フォーマットの panic 防止 (#224, #243)
- セキュリティ: キーボード配列ウィンドウの JS 注入対策 (#221, #240)、osascript エスケープ統一 (#223, #241)

### 依存・基盤
- **kanata v1.12.0 に更新** (#214, #251。muhenkan.kbd は実バイナリで valid 確認済み)
- Vite 7 + Vitest 4 (#232, #247。npm 脆弱性 7→0 件)
- CI 強化: shellcheck / PSScriptAnalyzer / clippy・fmt / クロス OS check (#226, #249)
- テスト拡大: frontend 113 テスト / Rust 96 テスト (#230, #250)、重複コード共通化 (#228/#229)